### PR TITLE
additions to flink-ha

### DIFF
--- a/repo/incubating/flink/demo/README.md
+++ b/repo/incubating/flink/demo/README.md
@@ -227,7 +227,7 @@ You should be able now to see the job running in your Flink Dashboard.
 You also should be able to see the detected fraud output in your actor logs:
 
 ```bash
-$ kubectl logs actor-f65f7745-ft5qj
+$ kubectl logs $(kubectl get pod -l app=flink-demo-actor -o jsonpath={.items..metadata.name})
 Broker:   small-kafka-0.small-svc:9093
 Topic:   fraud
 

--- a/repo/incubating/flink/demo/README.md
+++ b/repo/incubating/flink/demo/README.md
@@ -105,7 +105,7 @@ or setting the `DEPLOY_OWN_CLUSTER: "yes"` will deploy a dedicated cluster to us
 
 
 
-### Modifacation Demo
+### Modification Demo
 
 This has currently only been tested with:
 1) A jar that's present on the Flink Image
@@ -135,6 +135,31 @@ zk-zk-2   1/1   Running   0     21s
 zk-zk-1   1/1   Running   0     23s
 ```
 
+Create a Kafka cluster 
+```bash
+$ kubectl apply -f repo/stable/kafka/versions/0/
+$ kubectl get pods -w
+NAME      READY   STATUS              RESTARTS   AGE
+small-kafka-0   0/1   Pending   0     1s
+small-kafka-0   0/1   Pending   0     1s
+small-kafka-0   0/1   Pending   0     1s
+small-kafka-0   0/1   ContainerCreating   0     1s
+small-kafka-0   0/1   Running   0     18s
+small-kafka-0   1/1   Running   0     26s
+small-kafka-1   0/1   Pending   0     1s
+small-kafka-1   0/1   Pending   0     1s
+small-kafka-1   0/1   Pending   0     1s
+small-kafka-1   0/1   ContainerCreating   0     1s
+small-kafka-1   0/1   Running   0     3s
+small-kafka-1   1/1   Running   0     10s
+small-kafka-2   0/1   Pending   0     1s
+small-kafka-2   0/1   Pending   0     1s
+small-kafka-2   0/1   Pending   0     1s
+small-kafka-2   0/1   ContainerCreating   0     1s
+small-kafka-2   0/1   Running   0     3s
+small-kafka-2   1/1   Running   0     9s
+```
+
 and a Flink Application
 ```bash
 $ kubectl apply -f repo/incubating/flink/versions/0/flinkapplication-instance.yaml
@@ -155,10 +180,10 @@ application-mycluster-taskmanager-78cf898476-lzhcr   1/1   Running   0     3s
 application-mycluster-taskmanager-78cf898476-m6qdh   1/1   Running   0     5s
 ```
 
-The creation of the Job should happen during deployment, but we currently have it separated into a separate plan to allow better control.  Yes I know there's a lot of environment varaibles at the top
+The creation of the Job should happen during deployment, but we currently have it separated into a separate plan to allow better control. Yes we know there's a lot of environment variables at the top
 
 ```bash
-$ kubectl apply -f repo/incubating/flink/demo/scratch/run.yaml
+$ kubectl apply -f repo/incubating/flink/demo/scratch/submit.yaml
 $ kubectl logs jobs/application-submit-flink-job
 + PARALLELISM=1
 + ls -la /opt/flink/examples/streaming/StateMachineExample.jar

--- a/repo/incubating/flink/demo/README.md
+++ b/repo/incubating/flink/demo/README.md
@@ -223,7 +223,25 @@ Submitting Job... Response: {"jobid":"19f12f073433d71d3dd360d93ba74f29"}
 JobID: 19f12f073433d71d3dd360d93ba74f29
 ```
 
-This updates the config map with the `jobid` to be used elsewhere:
+You should be able now to see the job running in your Flink Dashboard. 
+You also should be able to see the detected fraud output in your actor logs:
+
+```bash
+$ kubectl logs actor-f65f7745-ft5qj
+Broker:   small-kafka-0.small-svc:9093
+Topic:   fraud
+
+Detected Fraud:   TransactionAggregate {startTimestamp=0, endTimestamp=1553669518000, totalAmount=11392:
+Transaction{timestamp=1553669433000, origin=3, target='1', amount=3202}
+Transaction{timestamp=1553669518000, origin=3, target='1', amount=8190}}
+
+Detected Fraud:   TransactionAggregate {startTimestamp=0, endTimestamp=1553669512000, totalAmount=15044:
+Transaction{timestamp=1553669457000, origin=9, target='8', amount=6819}
+Transaction{timestamp=1553669499000, origin=9, target='8', amount=853}
+Transaction{timestamp=1553669512000, origin=9, target='8', amount=7372}}
+```
+
+While your job was submitted, the config map with the `jobid` to be used elsewhere was also updated:
 ```bash
 $ kubectl get configmap application-flink -o jsonpath="{ .data.jobid }"
 2884cf4cfe7f75c1e5ab5de47ec93e50

--- a/repo/incubating/flink/demo/scratch/submit.yaml
+++ b/repo/incubating/flink/demo/scratch/submit.yaml
@@ -1,12 +1,11 @@
 apiVersion: kudo.k8s.io/v1alpha1
 kind: PlanExecution
 metadata:
-  name: run
+  name: submit
   namespace: default
 spec:
   instance:
     kind: Instance
     name: application
     namespace: default
-  planName: run
-  
+  planName: submit

--- a/repo/incubating/flink/versions/0/flinkapplication-frameworkversion.yaml
+++ b/repo/incubating/flink/versions/0/flinkapplication-frameworkversion.yaml
@@ -91,22 +91,22 @@ spec:
           metadata:
             name: {{PLAN_NAME}}-job
           spec:
+            volumes:
+            - name: ha
+              persistentVolumeClaim:
+                claimName: {{NAME}}-{{CLUSTER_NAME}}-ha
             restartPolicy: OnFailure
             {{#JAR_URL}}
             initContainers:
             - name: {{PLAN_NAME}}-download
               image: bash
               imagePullPolicy: Always
-              command:
-                - "/usr/local/bin/bash"
-              args: ['-c',
-              'export JOB_FILENAME=$(basename $JAR_URL); echo "JAR_URL: $JAR_URL FILE: $JOB_FILENAME JOBMANAGER: $JOBMANAGER"; apk add --no-cache jq curl;
-              curl -s $JAR_URL -o /ha/jobs/$JOB_FILENAME;
-              echo "=====================";
-              echo "saved and done"']
+              command: ['/bin/sh', '-c', 'mkdir -p /ha/artifacts; wget $JAR_URL -O $JAR_PATH; ls -al; ls -al /ha; ls -al /ha/artifacts']
               env:
               - name: JAR_URL
                 value: {{JAR_URL}}
+              - name: JAR_PATH
+                value: {{JAR_PATH}}
               - name: JOBMANAGER
                 {{#DEPLOY_OWN_CLUSTER}}
                 value: {{NAME}}-{{CLUSTER_NAME}}-jobmanager
@@ -135,13 +135,12 @@ spec:
                 value: {{CLASSNAME}}
               - name: PROGRAM_ARGS
                 value: {{JOB_ARGUMENTS}}
+              volumeMounts:
+                - name: ha
+                  mountPath: /ha
               name: {{PLAN_NAME}}
               image: kudobuilder/flink-submitter:1.7.2
               imagePullPolicy: Always
-            volumes:
-            - name: ha
-              persistentVolumeClaim:
-                claimName: {{NAME}}-ha
     restart.yaml: |
       # job to start
       apiVersion: batch/v1

--- a/repo/incubating/flink/versions/0/flinkapplication-frameworkversion.yaml
+++ b/repo/incubating/flink/versions/0/flinkapplication-frameworkversion.yaml
@@ -147,18 +147,38 @@ spec:
       kind: Job
       metadata:
         namespace: default
-        name: restart-flink-job
+        name: {{PLAN_NAME}}-flink-job
       spec:
         template:
           metadata:
             name: {{PLAN_NAME}}-job
           spec:
+            volumes:
+            - name: ha
+              persistentVolumeClaim:
+                claimName: {{NAME}}-{{CLUSTER_NAME}}-ha
             restartPolicy: OnFailure
             {{#JAR_URL}}
             initContainers:
-            - name: download
-              # Do some download things here and save to a shared Volume
-              # TODO
+            - name: {{PLAN_NAME}}-download
+              image: bash
+              imagePullPolicy: Always
+              command: ['/bin/sh', '-c', 'mkdir -p /ha/artifacts; wget $JAR_URL -O $JAR_PATH; ls -al; ls -al /ha; ls -al /ha/artifacts']
+              env:
+              - name: JAR_URL
+                value: {{JAR_URL}}
+              - name: JAR_PATH
+                value: {{JAR_PATH}}
+              - name: JOBMANAGER
+                {{#DEPLOY_OWN_CLUSTER}}
+                value: {{NAME}}-{{CLUSTER_NAME}}-jobmanager
+                {{/DEPLOY_OWN_CLUSTER}}
+                {{^DEPLOY_OWN_CLUSTER}}
+                value: {{CLUSTER_NAME}}-jobmanager
+                {{/DEPLOY_OWN_CLUSTER}}
+              volumeMounts:
+              - name: ha
+                mountPath: /ha
             {{/JAR_URL}}
             containers:
             - env:
@@ -182,6 +202,9 @@ spec:
                   configMapKeyRef:
                     name: {{NAME}}-flink
                     key: "location"
+              volumeMounts:
+                - name: ha
+                  mountPath: /ha
               name: {{PLAN_NAME}}
               image: kudobuilder/flink-submitter:1.7.2
               imagePullPolicy: Always
@@ -191,19 +214,13 @@ spec:
       kind: Job
       metadata:
         namespace: default
-        name: stop-flink-job
+        name: {{PLAN_NAME}}-flink-job
       spec:
         template:
           metadata:
             name: {{PLAN_NAME}}-job
           spec:
             restartPolicy: OnFailure
-            {{#JAR_URL}}
-            initContainers:
-            - name: download
-              # Do some download things here and save to a shared Volume
-              # TODO
-            {{/JAR_URL}}
             containers:
             - env:
               - name: JAR_PATH
@@ -225,7 +242,6 @@ spec:
               name: {{PLAN_NAME}}
               image: kudobuilder/flink-submitter:1.7.2
               imagePullPolicy: Always
-
   tasks:
     dependencies:
       resources:

--- a/repo/incubating/flink/versions/0/flinkapplication-frameworkversion.yaml
+++ b/repo/incubating/flink/versions/0/flinkapplication-frameworkversion.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Framework
   parameters:
     - name: JAR_URL
-      description: Location of JAR to run
+      description: Location of Jar to run
       default: ""
       required: false
     - name: JAR_PATH
@@ -21,7 +21,6 @@ spec:
     - name: JOB_ARGUMENTS
       description: Arguments to pass to Job at runtime
       default: ""
-      trigger: restart
     - name: DEPLOY_OWN_CLUSTER
       default: "false"
     - name: CLUSTER_NAME
@@ -30,6 +29,32 @@ spec:
       description: Classname to run inside the Jar.
       default: ""
   templates:
+    rbac.yaml: |
+      # to avoid: Error from server (Forbidden): configmaps "application-flink" is forbidden:User "system:serviceaccount:default:default" cannot get resource "configmaps" in API group "" in the namespace "default"
+      kind: Role
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        namespace: {{NAMESPACE}}
+        name: flink-configmap-access-role
+      rules:
+        - apiGroups: [""]
+          resources: ["configmaps"]
+          verbs: ["get", "watch", "list", "create", "update", "delete", "patch"]
+      ---
+      kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: flink-configmap-rolebinding
+        namespace: {{NAMESPACE}}
+      subjects:
+        - kind: Group
+          name: system:serviceaccounts
+          apiGroup: rbac.authorization.k8s.io
+          namespace: {{NAMESPACE}}
+      roleRef:
+        kind: Role
+        name: flink-configmap-access-role
+        apiGroup: rbac.authorization.k8s.io
     cluster.yaml: |
       #need to create a rolebinding for the service account in use
       {{#DEPLOY_OWN_CLUSTER}}
@@ -67,23 +92,38 @@ spec:
             name: {{PLAN_NAME}}-job
           spec:
             restartPolicy: OnFailure
-             {{#JAR_URL}}
+            {{#JAR_URL}}
             initContainers:
-            - name: download
-              # Do some download things here and save to a shared Volume
-              # TODO
+            - name: {{PLAN_NAME}}-download
+              image: bash
+              imagePullPolicy: Always
+              command:
+                - "/usr/local/bin/bash"
+              args: ['-c',
+              'export JOB_FILENAME=$(basename $JAR_URL); echo "JAR_URL: $JAR_URL FILE: $JOB_FILENAME JOBMANAGER: $JOBMANAGER"; apk add --no-cache jq curl;
+              curl -s $JAR_URL -o /ha/jobs/$JOB_FILENAME;
+              echo "=====================";
+              echo "saved and done"']
+              env:
+              - name: JAR_URL
+                value: {{JAR_URL}}
+              - name: JOBMANAGER
+                {{#DEPLOY_OWN_CLUSTER}}
+                value: {{NAME}}-{{CLUSTER_NAME}}-jobmanager
+                {{/DEPLOY_OWN_CLUSTER}}
+                {{^DEPLOY_OWN_CLUSTER}}
+                value: {{CLUSTER_NAME}}-jobmanager
+                {{/DEPLOY_OWN_CLUSTER}}
+              volumeMounts:
+              - name: ha
+                mountPath: /ha
             {{/JAR_URL}}
             containers:
             - env:
               - name: JAR_PATH
-                {{#JAR_URL}}
-                value: /volume/{{NAME}}.jar
-                {{/JAR_URL}}
-                {{#JAR_PATH}}
                 value: {{JAR_PATH}}
-                {{/JAR_PATH}}
               - name: JOBMANAGER
-                 {{#DEPLOY_OWN_CLUSTER}}
+                {{#DEPLOY_OWN_CLUSTER}}
                 value: {{NAME}}-{{CLUSTER_NAME}}-jobmanager
                 {{/DEPLOY_OWN_CLUSTER}}
                 {{^DEPLOY_OWN_CLUSTER}}
@@ -98,6 +138,10 @@ spec:
               name: {{PLAN_NAME}}
               image: kudobuilder/flink-submitter:1.7.2
               imagePullPolicy: Always
+            volumes:
+            - name: ha
+              persistentVolumeClaim:
+                claimName: {{NAME}}-ha
     restart.yaml: |
       # job to start
       apiVersion: batch/v1
@@ -111,7 +155,7 @@ spec:
             name: {{PLAN_NAME}}-job
           spec:
             restartPolicy: OnFailure
-             {{#JAR_URL}}
+            {{#JAR_URL}}
             initContainers:
             - name: download
               # Do some download things here and save to a shared Volume
@@ -120,14 +164,9 @@ spec:
             containers:
             - env:
               - name: JAR_PATH
-                {{#JAR_URL}}
-                value: /volume/{{NAME}}.jar
-                {{/JAR_URL}}
-                {{#JAR_PATH}}
                 value: {{JAR_PATH}}
-                {{/JAR_PATH}}
               - name: JOBMANAGER
-                 {{#DEPLOY_OWN_CLUSTER}}
+                {{#DEPLOY_OWN_CLUSTER}}
                 value: {{NAME}}-{{CLUSTER_NAME}}-jobmanager
                 {{/DEPLOY_OWN_CLUSTER}}
                 {{^DEPLOY_OWN_CLUSTER}}
@@ -160,7 +199,7 @@ spec:
             name: {{PLAN_NAME}}-job
           spec:
             restartPolicy: OnFailure
-             {{#JAR_URL}}
+            {{#JAR_URL}}
             initContainers:
             - name: download
               # Do some download things here and save to a shared Volume
@@ -169,14 +208,9 @@ spec:
             containers:
             - env:
               - name: JAR_PATH
-                {{#JAR_URL}}
-                value: /volume/{{NAME}}.jar
-                {{/JAR_URL}}
-                {{#JAR_PATH}}
                 value: {{JAR_PATH}}
-                {{/JAR_PATH}}
               - name: JOBMANAGER
-                 {{#DEPLOY_OWN_CLUSTER}}
+                {{#DEPLOY_OWN_CLUSTER}}
                 value: {{NAME}}-{{CLUSTER_NAME}}-jobmanager
                 {{/DEPLOY_OWN_CLUSTER}}
                 {{^DEPLOY_OWN_CLUSTER}}
@@ -196,9 +230,10 @@ spec:
   tasks:
     dependencies:
       resources:
+        - rbac.yaml
         - cluster.yaml
         - config.yaml
-    run:
+    submit:
       resources:
         - start.yaml
     stop:
@@ -217,19 +252,19 @@ spec:
             - name: dependencies
               tasks:
                 - dependencies
-    run:
+    submit:
       strategy: serial
       phases:
-        - name: dependencies
+        - name: submit
           strategy: serial
           steps:
-            - name: start
+            - name: submit
               tasks:
-                - run
+                - submit
     stop:
       strategy: serial
       phases:
-        - name: dependencies
+        - name: stop
           strategy: serial
           steps:
             - name: stop
@@ -238,14 +273,9 @@ spec:
     restart:
       strategy: serial
       phases:
-        - name: stop
-          steps:
-          - name: stop
-            tasks:
-            - stop
-        - name: start
+        - name: restart
           strategy: serial
           steps:
-            - name: start
+            - name: restart
               tasks:
                 - restart

--- a/repo/incubating/flink/versions/0/flinkapplication-instance.yaml
+++ b/repo/incubating/flink/versions/0/flinkapplication-instance.yaml
@@ -53,3 +53,4 @@ spec:
     JAR_URL: "https://downloads.mesosphere.com/dcos-demo/flink/flink-job-1.0.jar"
     JAR_PATH: "/ha/jobs/flink-job-1.0.jar"
     JOB_ARGUMENTS: "--kafka_host small-kafka-0.small-svc.default.svc.cluster.local:9093"
+    CLASSNAME: "io.dcos.FinancialTransactionJob"

--- a/repo/incubating/flink/versions/0/flinkapplication-instance.yaml
+++ b/repo/incubating/flink/versions/0/flinkapplication-instance.yaml
@@ -50,7 +50,6 @@ spec:
     type: FrameworkVersion
   parameters:
     DEPLOY_OWN_CLUSTER: "yes"
-    JAR_URL: ""
-    JAR_PATH: "/opt/flink/examples/streaming/StateMachineExample.jar"
-    JOB_ARGUMENTS: "--error-rate 0.05 --sleep 50"
-    CLASSNAME: org.apache.flink.streaming.examples.statemachine.StateMachineExample
+    JAR_URL: "https://downloads.mesosphere.com/dcos-demo/flink/flink-job-1.0.jar"
+    JAR_PATH: "/ha/jobs/flink-job-1.0.jar"
+    JOB_ARGUMENTS: "--kafka_host small-kafka-0.small-svc.default.svc.cluster.local:9093"

--- a/repo/incubating/flink/versions/0/flinkapplication-instance.yaml
+++ b/repo/incubating/flink/versions/0/flinkapplication-instance.yaml
@@ -51,6 +51,6 @@ spec:
   parameters:
     DEPLOY_OWN_CLUSTER: "yes"
     JAR_URL: "https://downloads.mesosphere.com/dcos-demo/flink/flink-job-1.0.jar"
-    JAR_PATH: "/ha/jobs/flink-job-1.0.jar"
+    JAR_PATH: "/ha/artifacts/flink-job-1.0.jar"
     JOB_ARGUMENTS: "--kafka_host small-kafka-0.small-svc.default.svc.cluster.local:9093"
     CLASSNAME: "io.dcos.FinancialTransactionJob"


### PR DESCRIPTION
Fixed a few things and introduced a few more things to be fixed ;)

what I added:
- Added Kafka to the Readme
- Renamed plans/phases/steps
- First attempt via `initContainers` to download a custom job

Right now I need a fresh pair of eyes for the volumeMounts in initContainers. To the `start.yaml` I added the option that if the `JAR_URL` parameter is set it will attempt to download the specified file into the `/ha/jobs` dir. However, every time I try to submit the job, it fails with: `invalid type encountered <nil>`

More verbose:
```bash
{"level":"error","ts":1553583523.3391008,"logger":"kubebuilder.controller","caller":"controller/controller.go:209","msg":"Reconciler error","Controller":"planexecution-controller","Request":"default/submit","error":"invalid type encountered <nil>","stacktrace":"github.com/kudobuilder/kudo/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/fabianbaier/go/src/github.com/kudobuilder/kudo/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/kudobuilder/kudo/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/fabianbaier/go/src/github.com/kudobuilder/kudo/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\ngithub.com/kudobuilder/kudo/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/Users/fabianbaier/go/src/github.com/kudobuilder/kudo/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:157\ngithub.com/kudobuilder/kudo/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/Users/fabianbaier/go/src/github.com/kudobuilder/kudo/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/kudobuilder/kudo/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/fabianbaier/go/src/github.com/kudobuilder/kudo/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/kudobuilder/kudo/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/fabianbaier/go/src/github.com/kudobuilder/kudo/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

ideas? It stopped here and I couldn't add this init feature to the `restart.yaml`. Parameter Arguments passed in the `flinkapplication-instance.yaml` weren't tested either.