### PR TITLE
Minor Kafka Update

### DIFF
--- a/repo/stable/kafka/versions/0/kafka-frameworkversion.yaml
+++ b/repo/stable/kafka/versions/0/kafka-frameworkversion.yaml
@@ -67,9 +67,6 @@ spec:
         - pdb.yaml
         - configmap.yaml
         - statefulset.yaml
-    gke-cleanup:
-      resources:
-        - gke-cleanup.yaml
   templates:
     service.yaml: |
       apiVersion: v1
@@ -157,7 +154,7 @@ spec:
           ############################# Log Basics #############################
 
           # A comma separated list of directories under which to store log files
-          log.dirs=/var/lib/kafka
+          log.dirs=/var/lib/kafka/data
 
           # The default number of log partitions per topic. More partitions allow greater
           # parallelism for consumption, but this will also result in more files across
@@ -278,9 +275,7 @@ spec:
               command:
               - sh
               - -c
-              - "rm -rf /var/lib/kafka/lost+found; \
-              ls -al /var/lib/kafka; echo DONE; exec kafka-server-start.sh /config/server.properties \
-              --override broker.id=${HOSTNAME##*-}"
+              - "exec kafka-server-start.sh /config/server.properties --override broker.id=${HOSTNAME##*-}"
               env:
               - name: KAFKA_HEAP_OPTS
                 value : "-Xmx512M -Xms512M"
@@ -317,7 +312,7 @@ spec:
       strategy: serial
       phases:
         - name: deploy-kafka
-          strategy: parallel
+          strategy: serial
           steps:
             - name: deploy
               tasks:

--- a/repo/stable/kafka/versions/0/kafka-instance.yaml
+++ b/repo/stable/kafka/versions/0/kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
     framework: kafka
-  name: small
+  name: kafka
 spec:
   frameworkVersion:
     name: kafka-2.11-2.4.0
@@ -17,5 +17,5 @@ spec:
       type: Instance
   parameters:
     KAFKA_ZOOKEEPER_URI: zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181
-    KAFKA_ZOOKEEPER_PATH: "/small"
-    BROKERS_COUNT: "3"
+    KAFKA_ZOOKEEPER_PATH: "/kafka"
+    BROKER_COUNT: "1"


### PR DESCRIPTION
Changelog:

- Making `/var/lib/kafka/data` the data directory ( https://github.com/kudobuilder/kudo/issues/90#issuecomment-461383910 )
- Changing deployment strategy to `serial`
- Renaming the Kafka instance from `small` to `kafka`
- Setting `BROKER_COUNT` from `3` to `1`

Background:

When giving demos on Minikube and preparing for the quickstart video retake ( https://github.com/kudobuilder/kudo/issues/108 ) I noticed that on Minikube Kafka had an ugly `CrashLoopBackOff` that crashes it around 3 times (roughly 80s) before the first Kafka broker runs successfully ( see [video](https://cl.ly/e015f4ceeefb)):

```bash
zk-zk-2   1/1   Running   0     17s
zk-zk-0   1/1   Running   0     19s
zk-zk-1   1/1   Running   0     21s
small-kafka-0   0/1   Pending   0     0s
small-kafka-0   0/1   Pending   0     0s
small-kafka-0   0/1   Pending   0     0s
small-kafka-0   0/1   ContainerCreating   0     0s
small-kafka-0   0/1   Running   0     19s
small-kafka-0   0/1   Error   0     26s
small-kafka-0   0/1   Running   1     27s
small-kafka-0   0/1   Error   1     36s
small-kafka-0   0/1   CrashLoopBackOff   1     48s
small-kafka-0   0/1   Running   2     49s
small-kafka-0   0/1   Error   2     57s
small-kafka-0   0/1   CrashLoopBackOff   2     68s
small-kafka-0   0/1   Running   3     82s
```
This is because of problems with PersistentVolumes provisioning, in particular the given issue stated in the Changelog above shows the actual error message: `Found directory /var/lib/kafka/lost+found, 'lost+found' is not in the form of topic-partition`. 

With setting `/var/lib/kafka/data` as the data directory this is fixed without the need of any data being deleted (as discussed in the issue).