### PR TITLE
#11 - Increase Kafka readinessProbe timeout to 10s

### DIFF
--- a/repo/stable/kafka/versions/0/kafka-frameworkversion.yaml
+++ b/repo/stable/kafka/versions/0/kafka-frameworkversion.yaml
@@ -292,6 +292,7 @@ spec:
                     - sh
                     - -c
                     - "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server=localhost:{{BROKER_PORT}}"
+                timeoutSeconds: 10
             securityContext:
               runAsUser: 1000
               fsGroup: 1000


### PR DESCRIPTION
The default timeout of 1s caused Kafka to never be marked ready even though it was.