### PR TITLE
kafka: add more options to kafka operator + new healthcheck

### DIFF
--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/kafka.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/kafka.yaml
@@ -11,7 +11,7 @@ spec:
     namespace: default
     type: OperatorVersions
   parameters:
-    KAFKA_ZOOKEEPER_URI: "{{ .Name }}-zk-{{ .Name }}-zk-0.{{ .Name }}-zk-hs:2181,{{ .Name }}-zk-{{ .Name }}-zk-1.{{ .Name }}-zk-hs:2181,{{ .Name }}-zk-{{ .Name }}-zk-2.{{ .Name }}-zk-hs:2181"
-    KAFKA_ZOOKEEPER_PATH: "/kafka"
+    ZOOKEEPER_URI: "{{ .Name }}-zk-{{ .Name }}-zk-0.{{ .Name }}-zk-hs:2181,{{ .Name }}-zk-{{ .Name }}-zk-1.{{ .Name }}-zk-hs:2181,{{ .Name }}-zk-{{ .Name }}-zk-2.{{ .Name }}-zk-hs:2181"
+    ZOOKEEPER_PATH: "/kafka"
     BROKER_COUNT: "3"
-    KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    AUTO_CREATE_TOPICS_ENABLE: "true"

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -1,5 +1,5 @@
 name: "kafka"
-version: "0.1.0"
+version: "0.1.1"
 kudoVersion: 0.3.0
 kubernetesVersion: 1.5.1
 maintainers:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -2,52 +2,567 @@ BROKER_COUNT:
   description: "Number of brokers spun up for Kafka"
   default: "3"
   displayName: "Broker Count"
+
 BROKER_CPUS:
   description: "CPUs allocated to the Kafka Broker pods"
   default: "500m"
+
 BROKER_MEM:
   description: "Memory (limit) allocated to the Kafka Broker pods"
   default: "2048m"
+
 BROKER_PORT:
   description: "Port brokers run on"
   default: "9093"
+
 CLIENT_PORT:
   description: "Broker client port"
   default: "9092"
+
 CLIENT_PORT_ENABLED:
   default: "true"
+
 METRICS_PORT:
   description: "Port JMX_EXPORTER binds"
   default: "9094"
+
 METRICS_ENABLED:
   default: "true"
-KAFKA_NUM_PARTITIONS:
+
+NUM_PARTITIONS:
   description: "Number of partitions for Kafka topics"
   default: "3"
-KAFKA_ZOOKEEPER_URI:
+
+ZOOKEEPER_URI:
   description: |
     host and port information for Zookeeper connection.
     e.g. zk:2181,zk2:2181,zk3:2181
   default: "zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181"
   required: true
-KAFKA_ZOOKEEPER_PATH:
+
+ZOOKEEPER_PATH:
   description: "Path inside of KAFKA_ZOOKEEPER_URI to host data"
   default: "/kafka"
-KAFKA_AUTO_CREATE_TOPICS_ENABLE:
+
+AUTO_CREATE_TOPICS_ENABLE:
   default: "true"
-KAFKA_AUTO_LEADER_REBALANCE_ENABLE:
+
+AUTO_LEADER_REBALANCE_ENABLE:
   default: "true"
-KAFKA_BACKGROUND_THREADS:
+
+BACKGROUND_THREADS:
+  description: "The number of threads to use for various background processing tasks"
   default: "10"
-KAFKA_COMPRESSION_TYPE:
+
+COMPRESSION_TYPE:
   default: "producer"
-KAFKA_DELETE_TOPIC_ENABLE:
-  default: "true"
-KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS:
+  description: |
+    Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4').
+    It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.
+
+DELETE_TOPIC_ENABLE:
+  displayName: "delete.topic.enable"
+  default: "false"
+  description: "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off"
+
+DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS:
+  default: "1"
+  description: "The purge interval (in number of requests) of the delete records request purgatory"
+
+LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS:
   default: "300"
-KAKFA_LEADER_IMBALANCE_PER_BROKER_PERCENTAGE:
+  description: "The frequency with which the partition rebalance check is triggered by the controller"
+
+LEADER_IMBALANCE_PER_BROKER_PERCENTAGE:
   default: "10"
-KAFKA_LOG_FLUSH_INTERVAL_MESSAGES:
+  description: "The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage."
+
+LOG_FLUSH_INTERVAL_MESSAGES:
   default: "9223372036854775807"
-KAFKA_LOG_FLUSH_INTERVAL_MS:
+  description: "The number of messages accumulated on a log partition before messages are flushed to disk"
+
+LOG_FLUSH_INTERVAL_MS:
+  default: "9223372036854775807"
+  description: "The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used"
+
+LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS:
   default: "60000"
+  description: "The frequency with which we update the persistent record of the last flush which acts as the log recovery point"
+
+LOG_FLUSH_SCHEDULER_INTERVAL_MS:
+  default: "9223372036854775807"
+  description: "The frequency in ms that the log flusher checks whether any log needs to be flushed to disk"
+
+LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS:
+  default: "60000"
+  description: "The frequency with which we update the persistent record of log start offset"
+
+LOG_RETENTION_BYTES:
+  displayName: "log.retention.bytes"
+  description: "The maximum size of the log before deleting it"
+  default: "-1"
+  
+LOG_RETENTION_MS:
+  displayName: "log.retention.ms"
+  description: "The number of milliseconds to keep a log file before deleting it (in milliseconds) If not set, the value in log.retention.minutes is used"
+
+LOG_RETENTION_MINUTES:
+  displayName: "log.retention.minutes"
+  description: "The number of minutes to keep a log file before deleting it (in minutes), secondary to log.retention.ms property. If not set, the value in log.retention.hours is used"
+
+LOG_RETENTION_HOURS:
+  displayName: "log.retention.hours"
+  description: "The number of hours to keep a log file before deleting it (in hours), tertiary to log.retention.ms property"
+  default: "168"
+  
+LOG_ROLL_MS:
+  displayName: "log.roll.ms"
+  description: "The maximum time before a new log segment is rolled out (in milliseconds). If not set, the value in log.roll.hours is used"
+
+LOG_ROLL_JITTER_MS:
+  displayName: "log.roll.jitter.ms"
+  description: "The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used"
+
+LOG_ROLL_HOURS:
+  displayName: "log.roll.hours"
+  description: "The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property"
+  default: "168"
+
+LOG_ROLL_JITTER_HOURS:
+  displayName: "log.roll.jitter.hours"
+  description: "The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property"
+  default: "0"
+
+LOG_SEGMENT_BYTES:
+  displayName: "log.segment.bytes"
+  description: "The maximum size of a single log file"
+  default: "1073741824"
+
+LOG_SEGMENT_DELETE_DELAY_MS:
+  displayName: "log.segment.delete.delay.ms"
+  description: "The amount of time to wait before deleting a file from the filesystem"
+  default: "60000"
+
+MESSAGE_MAX_BYTES:
+  displayName: "message.max.bytes"
+  description: "The largest record batch size allowed by Kafka. If this is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that the they can fetch record batches this large.\nIn the latest message format version, records are always grouped into batches for efficiency. In previous message format versions, uncompressed records are not grouped into batches and this limit only applies to a single record in that case.\nThis can be set per topic with the topic level max.message.bytes config."
+  default: "1000012"
+
+MIN_INSYNC_REPLICAS:
+  displayName: "min.insync.replicas"
+  description: |
+    When a producer sets acks to "all" (or "-1") MIN_INSYNC_REPLICAS is the minimum number of replicas that must acknowledge a write for the write to be considered successful.
+    When used together, min.insync.replicas and acks allow you to enforce greater durability guarantees.
+    A typical scenario would be to create a topic with a replication factor of 3, set min.insync.replicas to 2, and produce with acks of "all".
+  default: "1"
+  
+NUM_IO_THREADS:
+  displayName: "num.io.threads"
+  description: "The number of threads that the server uses for processing requests, which may include disk I/O"
+  default: "8"
+
+NUM_NETWORK_THREADS:
+  displayName: "num.network.threads"
+  description: "The number of threads that the server uses for receiving requests from the network and sending responses to the network"
+  default: "3"
+
+NUM_RECOVERY_THREADS_PER_DATA_DIR:
+  displayName: "num.recovery.threads.per.data.dir"
+  description: "The number of threads per data directory to be used for log recovery at startup and flushing at shutdown"
+  default: "1"
+
+NUM_REPLICA_FETCHERS:
+  displayName: "num.replica.fetchers"
+  description: "Number of fetcher threads used to replicate messages from a source broker. Increasing this value can increase the degree of I/O parallelism in the follower broker."
+  default: "1"
+  
+OFFSET_METADATA_MAX_BYTES:
+  displayName: "offset.metadata.max.bytes"
+  description: "The maximum size for a metadata entry associated with an offset commit"
+  default: "4096"
+  
+OFFSETS_COMMIT_REQUIRED_ACKS:
+  displayName: "offsets.commit.required.acks"
+  description: "The required acks before the commit can be accepted. In general the default (-1) should not be overridden"
+  default: -1
+  
+OFFSETS_COMMIT_TIMEOUT_MS:
+  displayName: "offsets.commit.timeout.ms"
+  description: "Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout."
+  default: "5000"
+
+OFFSETS_LOAD_BUFFER_SIZE:
+  displayName: "offsets.load.buffer.size"
+  description: "Batch size for reading from the offsets segments when loading offsets into the cache."
+  default: "5242880"
+
+OFFSETS_RETENTION_CHECK_INTERVAL_MS:
+  displayName: "offsets.retention.check.interval.ms"
+  description: "Frequency at which to check for stale offsets"
+  default: "600000"
+
+OFFSETS_RETENTION_MINUTES:
+  displayName: "offsets.retention.minutes"
+  description: "Offsets older than this retention period will be discarded"
+  default: "1440"
+
+OFFSETS_TOPIC_COMPRESSION_CODEC:
+  displayName: "offsets.topic.compression.codec"
+  description: "Compression codec for the offsets topic - compression may be used to achieve \"atomic\" commits"
+  default: "0"
+  
+OFFSETS_TOPIC_NUM_PARTITIONS:
+  displayName: "offsets.topic.num.partitions"
+  description: "The number of partitions for the offset commit topic (should not change after deployment)"
+  default: "50"
+
+OFFSETS_TOPIC_REPLICATION_FACTOR:
+  displayName: "offsets.topic.replication.factor"
+  description: "The replication factor for the offsets topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement."
+  default: "3"
+
+OFFSETS_TOPIC_SEGMENT_BYTES:
+  displayName: "offsets.topic.segment.bytes"
+  description: "The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads"
+  default: "104857600"
+
+QUEUED_MAX_REQUESTS:
+  displayName: "queued.max.requests"
+  description: "The number of queued requests allowed before blocking the network threads"
+  default: "500"
+
+QUEUED_MAX_REQUEST_BYTES:
+  displayName: "queued.max.request.bytes"
+  description: "The number of queued bytes allowed before no more requests are read"
+  default: -1
+  
+QUOTA_CONSUMER_DEFAULT:
+  displayName: "quota.consumer.default"
+  description: "Used only when dynamic default quotas are not configured for or in Zookeeper. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second"
+  default: "9223372036854775807"
+  
+QUOTA_PRODUCER_DEFAULT:
+  displayName: "quota.producer.default"
+  description: "Used only when dynamic default quotas are not configured for , or in Zookeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second"
+  default: "9223372036854775807"
+  
+REPLICA_FETCH_MAX_BYTES:
+  displayName: "replica.fetch.max.bytes"
+  description: "The number of bytes of messages to attempt to fetch for each partition. This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value the record batch will still be returned to ensure that progress can be made. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config)."
+  default: "1048576"
+  
+REPLICA_FETCH_MIN_BYTES:
+  displayName: "replica.fetch.min.bytes"
+  description: "Minimum bytes expected for each fetch response. If not enough bytes, wait up to replicaMaxWaitTimeMs"
+  default: "1"
+  
+REPLICA_FETCH_WAIT_MAX_MS:
+  displayName: "replica.fetch.wait.max.ms"
+  description: "Max wait time for each fetcher request issued by follower replicas. This value should always be less than the replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics"
+  default: "500"
+  
+REPLICA_FETCH_RESPONSE_MAX_BYTES:
+  displayName: "replica.fetch.response.max.bytes"
+  description: "Maximum bytes expected for the entire fetch response. Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value the record batch will still be returned to ensure that progress can be made. As such this is not an absolute maximum. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config)."
+  default: "10485760"
+
+REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS:
+  displayName: "replica.high.watermark.checkpoint.interval.ms"
+  description: "The frequency with which the high watermark is saved out to disk"
+  default: "5000"
+  
+REPLICA_LAG_TIME_MAX_MS:
+  displayName: "replica.lag.time.max.ms"
+  description: "If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time, the leader will remove the follower from isr"
+  default: "10000"
+  
+REPLICA_SOCKET_RECEIVE_BUFFER_BYTES:
+  displayName: "replica.socket.receive.buffer.bytes"
+  description: "The socket receive buffer for network requests"
+  default: "65536"
+  
+REPLICA_SOCKET_TIMEOUT_MS:
+  displayName: "replica.socket.timeout.ms"
+  description: "The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms"
+  default: "30000"
+  
+REPLICATION_QUOTA_WINDOW_NUM:
+  displayName: "replication.quota.window.num"
+  description: "The number of samples to retain in memory for replication quotas"
+  default: "11"
+
+REPLICATION_QUOTA_WINDOW_SIZE_SECONDS:
+  displayName: "replication.quota.window.size.seconds"
+  description: "The time span of each sample for replication quotas"
+  default: "1"
+
+REQUEST_TIMEOUT_MS:
+  displayName: "request.timeout.ms"
+  description: "The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted."
+  default: "30000"
+  
+SOCKET_RECEIVE_BUFFER_BYTES:
+  displayName: "socket.receive.buffer.bytes"
+  description: "The SO_RCVBUF buffer of the socket sever sockets. If the value is -1 the OS default will be used."
+  default: "102400"
+  
+SOCKET_REQUEST_MAX_BYTES:
+  displayName: "socket.request.max.bytes"
+  description: "The maximum number of bytes in a socket request"
+  default: "104857600"
+
+SOCKET_SEND_BUFFER_BYTES:
+  displayName: "socket.send.buffer.bytes"
+  description: "The SO_SNDBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used."
+  default: "102400"
+  
+UNCLEAN_LEADER_ELECTION_ENABLE:
+  displayName: "unclean.leader.election.enable"
+  description: "Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss"
+  default: "false"
+  
+ZOOKEEPER_SESSION_TIMEOUT_MS:
+  displayName: "zookeeper.session.timeout.ms"
+  description: "Zookeeper session timeout"
+  default: "6000"
+  
+CONNECTIONS_MAX_IDLE_MS:
+  displayName: "connections.max.idle.ms"
+  description: "Idle connections timeout: the server socket processor threads close the connections that idle more than this"
+  default: "600000"
+  
+CONTROLLED_SHUTDOWN_ENABLE:
+  displayName: "controlled.shutdown.enable"
+  description: "Enable controlled shutdown of the server"
+  default: "true"
+  
+CONTROLLED_SHUTDOWN_MAX_RETRIES:
+  displayName: "controlled.shutdown.max.retries"
+  description: "Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens"
+  default: "3"
+  
+CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS:
+  displayName: "controlled.shutdown.retry.backoff.ms"
+  description: "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying."
+  default: "5000"
+  
+CONTROLLER_SOCKET_TIMEOUT_MS:
+  displayName: "controller.socket.timeout.ms"
+  description: "The socket timeout for controller-to-broker channels"
+  default: "30000"
+  
+DEFAULT_REPLICATION_FACTOR:
+  displayName: "default.replication.factor"
+  description: "Default replication factors for automatically created topics"
+  default: "1"
+  
+FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS:
+  displayName: "fetch.purgatory.purge.interval.requests"
+  description: "The purge interval (in number of requests) of the fetch request purgatory"
+  default: "1000"
+  
+GROUP_MAX_SESSION_TIMEOUT_MS:
+  displayName: "group.max.session.timeout.ms"
+  description: "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures."
+  default: "300000"
+  
+GROUP_MIN_SESSION_TIMEOUT_MS:
+  displayName: "group.min.session.timeout.ms"
+  description: "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating which can overwhelm broker resources."
+  default: "6000"
+  
+GROUP_INITIAL_REBALANCE_DELAY_MS:
+  displayName: "group.initial.rebalance.delay.ms"
+  description: "The amount of time the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins."
+  default: "3000"
+  
+INTER_BROKER_PROTOCOL_VERSION:
+  displayName: "inter.broker.protocol.version"
+  description: "Specify which version of the inter-broker protocol will be used, which must align with log.message.format.version. This is typically bumped *serially* one broker at a time, *after* all brokers were upgraded to a new version. Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1, 0.10.0.0, 0.10.1.x, 0.10.2.x, 0.11.0.0, 1.0, 1.1. Check ApiVersion for the full list."
+  default: "2.1"
+  
+LOG_MESSAGE_FORMAT_VERSION:
+  displayName: "log.message.format.version"
+  description: "Specify which version of the log message format will be used, which must align with inter.broker.protocol.version. This is a new setting as of 0.10.0.0, and should be left at 0.9.0 until clients are updated to 0.10.0.x. Similarly it should be left at 0.10.0 until all clients are updated to 0.11.0. This is typically bumped *serially* one broker at a time, *after* all inter-protocol versions are updated. Clients on earlier versions may see a performance penalty if this is increased before they've upgraded. See the latest Kafka documentation for details."
+  default: "2.1"
+  
+LOG_CLEANER_BACKOFF_MS:
+  displayName: "log.cleaner.backoff.ms"
+  description: "The amount of time to sleep when there are no logs to clean"
+  default: "15000"
+
+LOG_CLEANER_DEDUPE_BUFFER_SIZE:
+  displayName: "log.cleaner.dedupe.buffer.size"
+  description: "The total memory used for log deduplication across all cleaner threads"
+  default: "134217728"
+  
+LOG_CLEANER_DELETE_RETENTION_MS:
+  displayName: "log.cleaner.delete.retention.ms"
+  description: "How long are delete records retained?"
+  default: "86400000"
+  
+LOG_CLEANER_ENABLE:
+  displayName: "log.cleaner.enable"
+  description: "Enable the log cleaner process to run on the server. Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size."
+  default: "true"
+  
+LOG_CLEANER_IO_BUFFER_LOAD_FACTOR:
+  displayName: "log.cleaner.io.buffer.load.factor"
+  description: "Log cleaner dedupe buffer load factor. The percentage full the dedupe buffer can become. A higher value will allow more log to be cleaned at once but will lead to more hash collisions"
+  default: "0.9"
+  
+LOG_CLEANER_IO_BUFFER_SIZE:
+  displayName: "log.cleaner.io.buffer.size"
+  description: "The total memory used for log cleaner I/O buffers across all cleaner threads"
+  default: "524288"
+
+LOG_CLEANER_IO_MAX_BYTES_PER_SECOND:
+  displayName: "log.cleaner.io.max.bytes.per.second"
+  description: "The log cleaner will be throttled so that the sum of its read and write i/o will be less than this value on average"
+  default: "1.7976931348623157e+308"
+  
+LOG_CLEANER_MIN_CLEANABLE_RATIO:
+  displayName: "log.cleaner.min.cleanable.ratio"
+  description: "The minimum ratio of dirty log to total log for a log to eligible for cleaning"
+  default: "0.5"
+  
+LOG_CLEANER_MIN_COMPACTION_LAG_MS:
+  displayName: "log.cleaner.min.compaction.lag.ms"
+  description: "The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted."
+  default: "0"
+  
+LOG_CLEANER_THREADS:
+  displayName: "log.cleaner.threads"
+  description: "The number of background threads to use for log cleaning"
+  default: "1"
+
+LOG_CLEANUP_POLICY:
+  displayName: "log.cleanup.policy"
+  description: "The default cleanup policy for segments beyond the retention window. A comma separated list of valid policies. Valid policies are: \"delete\" and \"compact\""
+  default: "delete"
+  
+LOG_INDEX_INTERVAL_BYTES:
+  displayName: "log.index.interval.bytes"
+  description: "The interval with which we add an entry to the offset index"
+  default: "4096"
+
+LOG_INDEX_SIZE_MAX_BYTES:
+  displayName: "log.index.size.max.bytes"
+  description: "The maximum size in bytes of the offset index"
+  default: "10485760"
+
+LOG_PREALLOCATE:
+  displayName: "log.preallocate"
+  description: "Should pre allocate file when create new segment? If you are using Kafka on Windows you probably need to set it to true."
+  default: "false"
+  
+LOG_RETENTION_CHECK_INTERVAL_MS:
+  displayName: "log.retention.check.interval.ms"
+  description: "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion"
+  default: "300000"
+
+MAX_CONNECTIONS_PER_IP:
+  displayName: "max.connections.per.ip"
+  description: "The maximum number of connections we allow from each ip address"
+  default: "2147483647"
+
+MAX_CONNECTIONS_PER_IP_OVERRIDES:
+  displayName: "max.connections.per.ip.overrides"
+  description: "Per-ip or hostname overrides to the default maximum number of connections"
+  default: ""
+  
+PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS:
+  displayName: "producer.purgatory.purge.interval.requests"
+  description: "The purge interval (in number of requests) of the producer request purgatory"
+  default: "1000"
+  
+REPLICA_FETCH_BACKOFF_MS:
+  displayName: "replica.fetch.backoff.ms"
+  description: "The amount of time to sleep when fetch partition error occurs."
+  default: "1000"
+
+RESERVED_BROKER_MAX_ID:
+  displayName: "reserved.broker.max.id"
+  description: "Max number that can be used for a broker.id"
+  default: "1000"
+
+METRIC_REPORTERS:
+  displayName: "metric.reporters"
+  description: "Java class to collect/report broker metrics"
+  default: ""
+  
+METRICS_NUM_SAMPLES:
+  displayName: "metrics.num.samples"
+  description: "The number of samples maintained to compute metrics."
+  default: "2"
+
+METRICS_SAMPLE_WINDOW_MS:
+  displayName: "metrics.sample.window.ms"
+  description: "The window of time a metrics sample is computed over."
+  default: "30000"
+
+QUOTA_WINDOW_NUM:
+  displayName: "quota.window.num"
+  description: "The number of samples to retain in memory for client quotas"
+  default: "11"
+
+QUOTA_WINDOW_SIZE_SECONDS:
+  displayName: "quota.window.size.seconds"
+  description: "The time span of each sample for client quotas"
+  default: "1"
+
+SSL_ENDPOINT_IDENTIFICATION_ENABLED:
+  displayName: "ssl.endpoint.identification.enabled"
+  description: "By default enables the hostname verification when TLS connections are established between Kafka brokers. To disable hostname verification leave this option unchecked"
+  default: "true"
+  
+TRANSACTION_STATE_LOG_SEGMENT_BYTES:
+  displayName: "transaction.state.log.segment.bytes"
+  description: "The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads"
+  default: "104857600"
+  
+TRANSACTION_REMOVE_EXPIRED_TRANSACTION_CLEANUP_INTERVAL_MS:
+  displayName: "transaction.remove.expired.transaction.cleanup.interval.ms"
+  description: "The interval at which to remove transactions that have expired due to transactional.id.expiration.ms passing"
+  default: "3600000"
+  
+TRANSACTION_MAX_TIMEOUT_MS:
+  displayName: "transaction.max.timeout.ms"
+  description: "The maximum allowed timeout for transactions. If a client's requested transaction time exceeds this then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout which can stall consumers reading from topics included in the transaction."
+  default: "900000"
+  
+TRANSACTION_STATE_LOG_NUM_PARTITIONS:
+  displayName: "transaction.state.log.num.partitions"
+  description: "The number of partitions for the transaction topic (should not change after deployment)."
+  default: "50"
+  
+TRANSACTION_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS:
+  displayName: "transaction.abort.timed.out.transaction.cleanup.interval.ms"
+  description: "The interval at which to rollback transactions that have timed out"
+  default: "60000"
+
+TRANSACTION_STATE_LOG_LOAD_BUFFER_SIZE:
+  displayName: "transaction.state.log.load.buffer.size"
+  description: "Batch size for reading from the transaction log segments when loading producer ids and transactions into the cache."
+  default: "5242880"
+
+TRANSACTION_STATE_LOG_REPLICATION_FACTOR:
+  displayName: "transaction.state.log.replication.factor"
+  description: "The replication factor for the transaction topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement."
+  default: "3"
+
+TRANSACTION_STATE_LOG_MIN_ISR:
+  displayName: "transaction.state.log.min.isr"
+  description: "Overridden min.insync.replicas config for the transaction topic."
+  default: "2"
+  
+TRANSACTIONAL_ID_EXPIRATION_MS:
+  displayName: "transactional.id.expiration.ms"
+  description: "The maximum amount of time in ms that the transaction coordinator will wait before proactively expire a producer's transactional id without receiving any transaction status updates from it."
+  default: "604800000"
+  
+ZOOKEEPER_SYNC_TIME_MS:
+  displayName: "zookeeper.sync.time.ms"
+  description: "How far a ZK follower can be behind a ZK leader"
+  default: "2000"
+

--- a/repository/kafka/operator/templates/configmap.yaml
+++ b/repository/kafka/operator/templates/configmap.yaml
@@ -15,70 +15,39 @@ data:
     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     # See the License for the specific language governing permissions and
     # limitations under the License.
-
     # see kafka.server.KafkaConfig for additional details and defaults
 
-    ############################# Server Basics #############################
+    # The number of threads handling network requests
+    num.network.threads={{ .Params.NUM_NETWORK_THREADS }}
 
-    # The id of the broker. This must be set to a unique integer for each broker.
-    # broker.id=${HOSTNAME##*-}
-    ############################# Socket Server Settings #############################
-
-    # The address the socket server listens on. It will get the value returned from
-    # java.net.InetAddress.getCanonicalHostName() if not configured.
-    #   FORMAT:
-    #     listeners = listener_name://host_name:port
-    #   EXAMPLE:
-    #     listeners = PLAINTEXT://your.host.name:9092
-    #listeners=PLAINTEXT://:{{ .Params.BROKER_PORT }}
-
-    # Hostname and port the broker will advertise to producers and consumers. If not set,
-    # it uses the value for "listeners" if configured.  Otherwise, it will use the value
-    # returned from java.net.InetAddress.getCanonicalHostName().
-    #advertised.listeners=PLAINTEXT://your.host.name:9092
-
-    # Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
-    #listener.security.protocol.map=PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
-
-    # The number of threads that the server uses for receiving requests from the network and sending responses to the network
-    num.network.threads=3
-
-    # The number of threads that the server uses for processing requests, which may include disk I/O
-    num.io.threads=8
+    # The number of threads doing disk I/O
+    num.io.threads={{ .Params.NUM_IO_THREADS }}
 
     # The send buffer (SO_SNDBUF) used by the socket server
-    socket.send.buffer.bytes=102400
+    socket.send.buffer.bytes={{ .Params.SOCKET_SEND_BUFFER_BYTES }}
 
     # The receive buffer (SO_RCVBUF) used by the socket server
-    socket.receive.buffer.bytes=102400
+    socket.receive.buffer.bytes={{ .Params.SOCKET_RECEIVE_BUFFER_BYTES }}
 
     # The maximum size of a request that the socket server will accept (protection against OOM)
-    socket.request.max.bytes=104857600
+    socket.request.max.bytes={{ .Params.SOCKET_REQUEST_MAX_BYTES }}
 
+    ############################# Authorization Settings #############################
+    # TODO support Security settings
 
     ############################# Log Basics #############################
 
     # A comma separated list of directories under which to store log files
-    # log.dirs=/var/lib/kafka/data
+    # log.dirs= determined by the mounted volume datadir
 
     # The default number of log partitions per topic. More partitions allow greater
     # parallelism for consumption, but this will also result in more files across
     # the brokers.
-    num.partitions={{ .Params.KAFKA_NUM_PARTITIONS }}
+    num.partitions={{ .Params.NUM_PARTITIONS }}
 
     # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
     # This value is recommended to be increased for installations with data dirs located in RAID array.
-    num.recovery.threads.per.data.dir=1
-
-    ############################# Internal Topic Settings  #############################
-    # The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
-    # For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
-    offsets.topic.replication.factor=1
-    transaction.state.log.replication.factor=1
-    transaction.state.log.min.isr=1
-    auto.create.topics.enable={{ .Params.KAFKA_AUTO_CREATE_TOPICS_ENABLE }}
-    auto.leader.rebalance.enable={{ .Params.KAFKA_AUTO_LEADER_REBALANCE_ENABLE }}
-    delete.topic.enable={{ .Params.KAFKA_DELETE_TOPIC_ENABLE }}
+    num.recovery.threads.per.data.dir={{ .Params.NUM_RECOVERY_THREADS_PER_DATA_DIR }}
 
     ############################# Log Flush Policy #############################
 
@@ -92,10 +61,9 @@ data:
     # every N messages (or both). This can be done globally and overridden on a per-topic basis.
 
     # The number of messages to accept before forcing a flush of data to disk
-    #log.flush.interval.messages=10000
+    log.flush.interval.messages={{ .Params.LOG_FLUSH_INTERVAL_MESSAGES }}
 
-    # The maximum amount of time a message can sit in a log before we force a flush
-    #log.flush.interval.ms=1000
+    log.flush.interval.ms={{ .Params.LOG_FLUSH_INTERVAL_MS }}
 
     ############################# Log Retention Policy #############################
 
@@ -104,19 +72,27 @@ data:
     # A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
     # from the end of the log.
 
-    # The minimum age of a log file to be eligible for deletion due to age
-    log.retention.hours=168
+    # The minimum age of a log file to be eligible for deletion.
+    {{ if .Params.LOG_RETENTION_MS }}
+    log.retention.ms={{ .Params.LOG_RETENTION_MS }}
+    {{ end }}
+    {{ if .Params.LOG_RETENTION_MINUTES }}
+    log.retention.minutes={{ .Params.LOG_RETENTION_MINUTES }}
+    {{ end }}
+    {{ if .Params.LOG_RETENTION_HOURS }}
+    log.retention.hours={{ .Params.LOG_RETENTION_HOURS }}
+    {{ end }}
 
-    # A size-based retention policy for logs. Segments are pruned from the log unless the remaining
-    # segments drop below log.retention.bytes. Functions independently of log.retention.hours.
-    #log.retention.bytes=1073741824
+    # A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
+    # segments don't drop below log.retention.bytes.
+    log.retention.bytes={{ .Params.LOG_RETENTION_BYTES }}
 
     # The maximum size of a log segment file. When this size is reached a new log segment will be created.
-    log.segment.bytes=1073741824
+    log.segment.bytes={{ .Params.LOG_SEGMENT_BYTES }}
 
     # The interval at which log segments are checked to see if they can be deleted according
     # to the retention policies
-    log.retention.check.interval.ms=300000
+    log.retention.check.interval.ms={{ .Params.LOG_RETENTION_CHECK_INTERVAL_MS }}
 
     ############################# Zookeeper #############################
 
@@ -125,20 +101,148 @@ data:
     # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
     # You can also append an optional chroot string to the urls to specify the
     # root directory for all kafka znodes.
-    zookeeper.connect={{ .Params.KAFKA_ZOOKEEPER_URI }}{{ .Params.KAFKA_ZOOKEEPER_PATH }}
+    zookeeper.connect={{ .Params.ZOOKEEPER_URI }}{{ .Params.ZOOKEEPER_PATH }}
 
     # Timeout in ms for connecting to zookeeper
-    zookeeper.connection.timeout.ms=6000
+    # zookeeper.connection.timeout.ms= defaults to zookeeper.session.timeout.ms
 
 
-    ############################# Group Coordinator Settings #############################
+    ########################### Additional Parameters ########################
 
-    # The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
-    # The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms.
-    # The default value for this is 3 seconds.
-    # We override this to 0 here as it makes for a better out-of-the-box experience for development and testing.
-    # However, in production environments the default value of 3 seconds is more suitable as this will help to avoid unnecessary, and potentially expensive, rebalances during application startup.
-    group.initial.rebalance.delay.ms=0
+    auto.create.topics.enable={{ .Params.AUTO_CREATE_TOPICS_ENABLE }}
+    auto.leader.rebalance.enable={{ .Params.AUTO_LEADER_REBALANCE_ENABLE }}
+
+    background.threads={{ .Params.BACKGROUND_THREADS }}
+
+    compression.type={{ .Params.COMPRESSION_TYPE }}
+
+    connections.max.idle.ms={{ .Params.CONNECTIONS_MAX_IDLE_MS }}
+
+    controlled.shutdown.enable={{ .Params.CONTROLLED_SHUTDOWN_ENABLE }}
+    controlled.shutdown.max.retries={{ .Params.CONTROLLED_SHUTDOWN_MAX_RETRIES }}
+    controlled.shutdown.retry.backoff.ms={{ .Params.CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS }}
+    controller.socket.timeout.ms={{ .Params.CONTROLLER_SOCKET_TIMEOUT_MS }}
+
+    default.replication.factor={{ .Params.DEFAULT_REPLICATION_FACTOR }}
+
+    delete.topic.enable={{ .Params.DELETE_TOPIC_ENABLE }}
+
+    delete.records.purgatory.purge.interval.requests={{ .Params.DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS }}
+
+    fetch.purgatory.purge.interval.requests={{ .Params.FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS }}
+
+    group.max.session.timeout.ms={{ .Params.GROUP_MAX_SESSION_TIMEOUT_MS }}
+    group.min.session.timeout.ms={{ .Params.GROUP_MIN_SESSION_TIMEOUT_MS }}
+    group.initial.rebalance.delay.ms={{ .Params.GROUP_INITIAL_REBALANCE_DELAY_MS }}
+
+    inter.broker.protocol.version={{ .Params.INTER_BROKER_PROTOCOL_VERSION }}
+
+    leader.imbalance.check.interval.seconds={{ .Params.LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS }}
+    leader.imbalance.per.broker.percentage={{ .Params.LEADER_IMBALANCE_PER_BROKER_PERCENTAGE }}
+
+    log.cleaner.backoff.ms={{ .Params.LOG_CLEANER_BACKOFF_MS }}
+    log.cleaner.dedupe.buffer.size={{ .Params.LOG_CLEANER_DEDUPE_BUFFER_SIZE }}
+    log.cleaner.delete.retention.ms={{ .Params.LOG_CLEANER_DELETE_RETENTION_MS }}
+    log.cleaner.enable={{ .Params.LOG_CLEANER_ENABLE }}
+    log.cleaner.io.buffer.load.factor={{ .Params.LOG_CLEANER_IO_BUFFER_LOAD_FACTOR }}
+    log.cleaner.io.buffer.size={{ .Params.LOG_CLEANER_IO_BUFFER_SIZE }}
+    log.cleaner.io.max.bytes.per.second={{ .Params.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND }}
+    log.cleaner.min.cleanable.ratio={{ .Params.LOG_CLEANER_MIN_CLEANABLE_RATIO }}
+    log.cleaner.min.compaction.lag.ms={{ .Params.LOG_CLEANER_MIN_COMPACTION_LAG_MS }}
+    log.cleaner.threads={{ .Params.LOG_CLEANER_THREADS }}
+    log.cleanup.policy={{ .Params.LOG_CLEANUP_POLICY }}
+
+    log.flush.offset.checkpoint.interval.ms={{ .Params.LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS }}
+    log.flush.scheduler.interval.ms={{ .Params.LOG_FLUSH_SCHEDULER_INTERVAL_MS }}
+    log.flush.start.offset.checkpoint.interval.ms={{ .Params.LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS }}
+
+    log.index.interval.bytes={{ .Params.LOG_INDEX_INTERVAL_BYTES }}
+    log.index.size.max.bytes={{ .Params.LOG_INDEX_SIZE_MAX_BYTES }}
+
+    log.message.format.version={{ .Params.LOG_MESSAGE_FORMAT_VERSION }}
+
+    log.preallocate={{ .Params.LOG_PREALLOCATE }}
+
+    {{ if .Params.LOG_ROLL_MS }}
+    log.roll.ms={{ .Params.LOG_ROLL_MS }}
+    {{ end }}
+    {{ if .Params.LOG_ROLL_HOURS }}
+    log.roll.hours={{ .Params.LOG_ROLL_HOURS }}
+    {{ end }}
+    {{ if .Params.LOG_ROLL_JITTER_MS }}
+    log.roll.jitter.ms={{ .Params.LOG_ROLL_JITTER_MS }}
+    {{ end }}
+    {{ if .Params.LOG_ROLL_JITTER_HOURS }}
+    log.roll.jitter.hours={{ .Params.LOG_ROLL_JITTER_HOURS }}
+    {{ end }}
+
+    log.segment.delete.delay.ms={{ .Params.LOG_SEGMENT_DELETE_DELAY_MS }}
+
+    max.connections.per.ip.overrides={{ .Params.MAX_CONNECTIONS_PER_IP_OVERRIDES }}
+    max.connections.per.ip={{ .Params.MAX_CONNECTIONS_PER_IP }}
+
+    message.max.bytes={{ .Params.MESSAGE_MAX_BYTES }}
+
+    metric.reporters={{ .Params.METRIC_REPORTERS }}
+    metrics.num.samples={{ .Params.METRICS_NUM_SAMPLES }}
+    metrics.sample.window.ms={{ .Params.METRICS_SAMPLE_WINDOW_MS }}
+
+    min.insync.replicas={{ .Params.MIN_INSYNC_REPLICAS }}
+
+    num.replica.fetchers={{ .Params.NUM_REPLICA_FETCHERS }}
+
+    offset.metadata.max.bytes={{ .Params.OFFSET_METADATA_MAX_BYTES }}
+    offsets.commit.required.acks={{ .Params.OFFSETS_COMMIT_REQUIRED_ACKS }}
+    offsets.commit.timeout.ms={{ .Params.OFFSETS_COMMIT_TIMEOUT_MS }}
+    offsets.load.buffer.size={{ .Params.OFFSETS_LOAD_BUFFER_SIZE }}
+    offsets.retention.check.interval.ms={{ .Params.OFFSETS_RETENTION_CHECK_INTERVAL_MS }}
+    offsets.retention.minutes={{ .Params.OFFSETS_RETENTION_MINUTES }}
+    offsets.topic.compression.codec={{ .Params.OFFSETS_TOPIC_COMPRESSION_CODEC }}
+    offsets.topic.num.partitions={{ .Params.OFFSETS_TOPIC_NUM_PARTITIONS }}
+    offsets.topic.replication.factor={{ .Params.OFFSETS_TOPIC_REPLICATION_FACTOR }}
+    offsets.topic.segment.bytes={{ .Params.OFFSETS_TOPIC_SEGMENT_BYTES }}
+
+    producer.purgatory.purge.interval.requests={{ .Params.PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS }}
+
+    queued.max.requests={{ .Params.QUEUED_MAX_REQUESTS }}
+    queued.max.request.bytes={{ .Params.QUEUED_MAX_REQUEST_BYTES }}
+    quota.consumer.default={{ .Params.QUOTA_CONSUMER_DEFAULT }}
+    quota.producer.default={{ .Params.QUOTA_PRODUCER_DEFAULT }}
+    quota.window.num={{ .Params.QUOTA_WINDOW_NUM }}
+    quota.window.size.seconds={{ .Params.QUOTA_WINDOW_SIZE_SECONDS }}
+
+    replica.fetch.backoff.ms={{ .Params.REPLICA_FETCH_BACKOFF_MS }}
+    replica.fetch.max.bytes={{ .Params.REPLICA_FETCH_MAX_BYTES }}
+    replica.fetch.min.bytes={{ .Params.REPLICA_FETCH_MIN_BYTES }}
+    replica.fetch.response.max.bytes={{ .Params.REPLICA_FETCH_RESPONSE_MAX_BYTES }}
+    replica.fetch.wait.max.ms={{ .Params.REPLICA_FETCH_WAIT_MAX_MS }}
+    replica.high.watermark.checkpoint.interval.ms={{ .Params.REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS }}
+    replica.lag.time.max.ms={{ .Params.REPLICA_LAG_TIME_MAX_MS }}
+    replica.socket.receive.buffer.bytes={{ .Params.REPLICA_SOCKET_RECEIVE_BUFFER_BYTES }}
+    replica.socket.timeout.ms={{ .Params.REPLICA_SOCKET_TIMEOUT_MS }}
+
+    replication.quota.window.num={{ .Params.REPLICATION_QUOTA_WINDOW_NUM }}
+    replication.quota.window.size.seconds={{ .Params.REPLICATION_QUOTA_WINDOW_SIZE_SECONDS }}
+
+    request.timeout.ms={{ .Params.REQUEST_TIMEOUT_MS }}
+
+    reserved.broker.max.id={{ .Params.RESERVED_BROKER_MAX_ID }}
+
+    transaction.state.log.segment.bytes={{ .Params.TRANSACTION_STATE_LOG_SEGMENT_BYTES }}
+    transaction.remove.expired.transaction.cleanup.interval.ms={{ .Params.TRANSACTION_REMOVE_EXPIRED_TRANSACTION_CLEANUP_INTERVAL_MS }}
+    transaction.max.timeout.ms={{ .Params.TRANSACTION_MAX_TIMEOUT_MS }}
+    transaction.state.log.num.partitions={{ .Params.TRANSACTION_STATE_LOG_NUM_PARTITIONS }}
+    transaction.abort.timed.out.transaction.cleanup.interval.ms={{ .Params.TRANSACTION_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS }}
+    transaction.state.log.load.buffer.size={{ .Params.TRANSACTION_STATE_LOG_LOAD_BUFFER_SIZE }}
+    transactional.id.expiration.ms={{ .Params.TRANSACTIONAL_ID_EXPIRATION_MS }}
+    transaction.state.log.replication.factor={{ .Params.TRANSACTION_STATE_LOG_REPLICATION_FACTOR }}
+    transaction.state.log.min.isr={{ .Params.TRANSACTION_STATE_LOG_MIN_ISR }}
+
+    unclean.leader.election.enable={{ .Params.UNCLEAN_LEADER_ELECTION_ENABLE }}
+
+    zookeeper.session.timeout.ms={{ .Params.ZOOKEEPER_SESSION_TIMEOUT_MS }}
+    zookeeper.sync.time.ms={{ .Params.ZOOKEEPER_SYNC_TIME_MS }}
+
 kind: ConfigMap
 metadata:
   creationTimestamp: 2016-03-30T18:14:41Z

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: k8skafka
           imagePullPolicy: Always
-          image: mesosphere/kafka:0.1-2.2.1
+          image: mesosphere/kafka:0.1.0-2.2.1
           resources:
             requests:
               memory: {{ .Params.BROKER_MEM }}
@@ -45,7 +45,7 @@ spec:
               value: "-javaagent:/opt/jmx-exporter/jmx_prometheus_javaagent.jar=9094:/opt/kafka/metrics-config.yml"
             {{ end }}
             - name: KAFKA_ZK_URI
-              value: {{ .Params.KAFKA_ZOOKEEPER_URI }}{{ .Params.KAFKA_ZOOKEEPER_PATH }}
+              value: {{ .Params.ZOOKEEPER_URI }}{{ .Params.ZOOKEEPER_PATH }}
             - name: GC_LOG_ENABLED
               value: "false"
             - name: LOG_DIR
@@ -70,6 +70,14 @@ spec:
                 - -c
                 - "$KAFKA_HOME/readiness-check.sh"
             timeoutSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - "$KAFKA_HOME/readiness-check.sh"
+            initialDelaySeconds: 10
+            periodSeconds: 10
       securityContext:
         runAsUser: 1000
         fsGroup: 1000


### PR DESCRIPTION
This PR updates the kafka operator to version `0.1.1`

- add 100 more parameters to configure Kafka properties and set them to tuned defaults.
- update the docker image to `mesosphere/kafka:0.1.0-2.2.1` 
       --> use port check for the health check instead of connection to zk 
- added livenessprobe