### PR TITLE
Include link to Kafka service-monitor.yaml in Kafka docs

### DIFF
--- a/repository/kafka/docs/v0.1/monitoring.md
+++ b/repository/kafka/docs/v0.1/monitoring.md
@@ -21,7 +21,7 @@ TargetPort:        9094/TCP
 
 To use the prometheus service monitor, its necessary to have installed the prometheus operator previously in the cluster.
 
-If the Kafka Cluster Service in the default namespace, we can use the next example of the service-monitor.
+If the Kafka Cluster Service in the default namespace, we can use the next example of the service-monitor. The `service-monitor.yaml` file referenced below is available ![here](https://raw.githubusercontent.com/kudobuilder/operators/master/repository/kafka/docs/v0.1/resources/service-monitor.yaml).
 ```
 kubectl create -f resources/service-monitor.yaml
 ```


### PR DESCRIPTION
What type of PR is this?

/kind documentation

What this PR does / why we need it:

New Kafka monitoring is awesome, but not obvious where the requisite YAML lives.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Yes, but docs only?



[Apologies in advance if I've butchered PR protocol here. Happy to accept feedback on how to improve!]