### PR TITLE
Change uses of .k8s.io to .kudo.dev

### DIFF
--- a/kudo-test.yaml
+++ b/kudo-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestSuite
 testDirs:
 - ./repository/zookeeper/tests

--- a/repository/flink/docs/demo/financial-fraud/README.md
+++ b/repository/flink/docs/demo/financial-fraud/README.md
@@ -24,8 +24,8 @@ Before you get started:
     - Use the KUDO CLI with the following command:
         ```bash
         $ kubectl kudo install zookeeper --package-version=0.1.0
-        framework.kudo.k8s.io/v1alpha1/zookeeper created
-        frameworkversion.kudo.k8s.io/v1alpha1/zookeeper-0.1.0 created
+        framework.kudo.dev/v1alpha1/zookeeper created
+        frameworkversion.kudo.dev/v1alpha1/zookeeper-0.1.0 created
         No Instance tied to this "zookeeper" version has been found. Do you want to create one? (Yes/no) no
 
         ```
@@ -34,8 +34,8 @@ Before you get started:
     - Use the KUDO CLI with the following command:
         ```bash
         $ kubectl kudo install kafka --package-version=0.1.0
-        framework.kudo.k8s.io/v1alpha1/kafka created
-        frameworkversion.kudo.k8s.io/v1alpha1/kafka-0.1.0 created
+        framework.kudo.dev/v1alpha1/kafka created
+        frameworkversion.kudo.dev/v1alpha1/kafka-0.1.0 created
         No Instance tied to this "kafka" version has been found. Do you want to create one? (Yes/no) no
 
         ```
@@ -66,7 +66,7 @@ Once everything is up, start the job:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/flink.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/flink.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/kafka.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/kafka.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/zookeeper.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/zookeeper.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/repository/flink/docs/demo/modifications/flinkapplication-framework.yaml
+++ b/repository/flink/docs/demo/modifications/flinkapplication-framework.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:

--- a/repository/flink/docs/demo/modifications/flinkapplication-frameworkversion.yaml
+++ b/repository/flink/docs/demo/modifications/flinkapplication-frameworkversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: FrameworkVersion
 metadata:
   labels:
@@ -58,7 +58,7 @@ spec:
     cluster.yaml: |
       #need to create a rolebinding for the service account in use
       {{#DEPLOY_OWN_CLUSTER}}
-      apiVersion: kudo.k8s.io/v1alpha1
+      apiVersion: kudo.dev/v1alpha1
       kind: Instance
       metadata:
         name: {{CLUSTER_NAME}}

--- a/repository/flink/docs/demo/modifications/flinkapplication-instance.yaml
+++ b/repository/flink/docs/demo/modifications/flinkapplication-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/repository/flink/docs/demo/modifications/flinkcluster-framework.yaml
+++ b/repository/flink/docs/demo/modifications/flinkcluster-framework.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Framework
 metadata:
   labels:

--- a/repository/flink/docs/demo/modifications/flinkcluster-frameworkversion.yaml
+++ b/repository/flink/docs/demo/modifications/flinkcluster-frameworkversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: FrameworkVersion
 metadata:
   labels:

--- a/repository/flink/docs/demo/modifications/flinkcluster-instance.yaml
+++ b/repository/flink/docs/demo/modifications/flinkcluster-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/repository/flink/docs/demo/modifications/scratch/restart.yaml
+++ b/repository/flink/docs/demo/modifications/scratch/restart.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   name: restart

--- a/repository/flink/docs/demo/modifications/scratch/stop.yaml
+++ b/repository/flink/docs/demo/modifications/scratch/stop.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   name: stop

--- a/repository/flink/docs/demo/modifications/scratch/submit.yaml
+++ b/repository/flink/docs/demo/modifications/scratch/submit.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   name: submit

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/00-assert.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/00-assert.yaml
@@ -1,8 +1,8 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestAssert
 timeout: 120
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: zk

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/00-install.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: zk

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/01-assert.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/01-assert.yaml
@@ -1,8 +1,8 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestAssert
 timeout: 60
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: zk

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/01-resize.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/01-resize.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: zk


### PR DESCRIPTION
The `.k8s.io` suffix is reserved for use by the Kubernetes project, so we need to use `kudo.dev` instead.

Fixes #49