### PR TITLE
[Flink] Ability to have AccessModes defined as a Parameter

### DIFF
--- a/repository/flink/operator/params.yaml
+++ b/repository/flink/operator/params.yaml
@@ -1,3 +1,6 @@
+flink_storage_accessmodes:
+    description: "Defines the access modes for Persistent Volume Claims e.g., can be mounted once read/write or many times read-only"
+    default: "ReadWriteOnce"
 flink_taskmanager_replicas:
     description: "Number of task managers to run"
     default: "2"

--- a/repository/flink/operator/templates/storage.yaml
+++ b/repository/flink/operator/templates/storage.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Namespace }}
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{ .Params.flink_storage_accessmodes }}
   resources:
     requests:
       storage: 1Gi
@@ -17,7 +17,7 @@ metadata:
   namespace: {{ .Namespace }}
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{ .Params.flink_storage_accessmodes }}
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
This PR is intended to make `accessModes` for PVCs modifiable through a parameter. Default value is `ReadWriteOnce` but can now easily be overwritten e.g. with `ReadWriteMany`.