### PR TITLE
kafka: fix typo in versioned docs

### DIFF
--- a/repository/kafka/docs/latest/README.md
+++ b/repository/kafka/docs/latest/README.md
@@ -1,4 +1,4 @@
-## KUDO Kafka v0.1.1
+## KUDO Kafka latest
 
 - [Installation](./install.md)
 - [Configuration](./configuration.md)

--- a/repository/kafka/docs/v0.2/README.md
+++ b/repository/kafka/docs/v0.2/README.md
@@ -1,4 +1,4 @@
-## KUDO Kafka v0.1.1
+## KUDO Kafka v0.2.0
 
 - [Installation](./install.md)
 - [Configuration](./configuration.md)


### PR DESCRIPTION
fix typo in the title of the `README.md` of versions