### PR TITLE
kafka: mismatch in service and statefulset pod

### DIFF
--- a/repository/kafka/operator/templates/service.yaml
+++ b/repository/kafka/operator/templates/service.yaml
@@ -19,4 +19,4 @@ spec:
   clusterIP: None
   selector:
     app: kafka
-    instance: {{ .Name }}
+    kudo.dev/instance: {{ .Name }}


### PR DESCRIPTION
after the merge of https://github.com/kudobuilder/kudo/pull/603/files kudo isn't adding the label `instance` but `kudo.dev/instance` 

this breaks the integration with operators using the service label `instance` 

