### PR TITLE
Ignore 'lost+found' folder when initialising DB

### DIFF
--- a/repository/mysql/operator/templates/mysql.yaml
+++ b/repository/mysql/operator/templates/mysql.yaml
@@ -38,6 +38,8 @@ spec:
       containers:
       - image: mysql:5.7
         name: mysql
+        args:
+        - "--ignore-db-dir=lost+found"
         env:
           # Use secret in real usage
         - name: MYSQL_ROOT_PASSWORD


### PR DESCRIPTION
This is a quick fix required when installing an instance via this operator on cloud
platforms such as AWS, in which the filesystem as presented might not be
truly empty.