### PR TITLE
Add velodrome and influxdb operators.

### DIFF
--- a/kudo-test.yaml
+++ b/kudo-test.yaml
@@ -20,3 +20,4 @@ testDirs:
 startKIND: true
 startKUDO: true
 timeout: 300
+parallel: 2

--- a/kudo-test.yaml
+++ b/kudo-test.yaml
@@ -7,10 +7,15 @@ kubectl:
 - kudo install --skip-instance ./repository/elastic/operator/
 - kudo install --skip-instance ./repository/flink/operator/
 - kudo install --skip-instance ./repository/kafka/operator/
+- kudo install --skip-instance ./repository/influxdb/operator/
 - kudo install --skip-instance ./repository/mysql/operator/
 - kudo install --skip-instance ./repository/redis/operator/
+- kudo install --skip-instance ./repository/velodrome/operator/
 - kudo install --skip-instance ./repository/zookeeper/operator/
 testDirs:
+- ./repository/influxdb/tests
+- ./repository/mysql/tests
+- ./repository/velodrome/tests
 - ./repository/zookeeper/tests
 startKIND: true
 startKUDO: true

--- a/repository/influxdb/README.md
+++ b/repository/influxdb/README.md
@@ -1,0 +1,3 @@
+# Influxdb Operator
+
+Deploys an influxdb instance.

--- a/repository/influxdb/operator/operator.yaml
+++ b/repository/influxdb/operator/operator.yaml
@@ -1,0 +1,21 @@
+name: "influxdb"
+version: "0.1.0"
+kudoVersion: 0.5.0
+kubernetesVersion: 1.5.1
+maintainers:
+  - Justin Taylor-Barrick <jbarrick@d2iq.com>
+url: https://www.influxdata.com/products/influxdb-overview/
+tasks:
+  infra:
+    resources:
+      - deploy.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: influxdb
+        strategy: parallel
+        steps:
+          - name: everything
+            tasks:
+              - infra

--- a/repository/influxdb/operator/params.yaml
+++ b/repository/influxdb/operator/params.yaml
@@ -1,0 +1,6 @@
+INFLUX_SECRET:
+  default: ""
+  description: Name of secret containing credentials for influxdb. Should contain a `username`, `password`, and `database` key.
+DISK_SIZE:
+  default: "100Gi"
+  description: Size of disk to provision for influxdb.

--- a/repository/influxdb/operator/templates/deploy.yaml
+++ b/repository/influxdb/operator/templates/deploy.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: influxdb
+  labels:
+    app: influxdb
+    instance: {{ .Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: influxdb
+      instance: {{ .Name }}
+  template:
+    metadata:
+      labels:
+        app: influxdb
+        instance: {{ .Name }}
+    spec:
+      containers:
+      - name: influxdb
+        image: quay.io/influxdb/influxdb:1.6
+        env:
+        - name: INFLUXDB_HTTP_AUTH_ENABLED
+          value: "true"
+        resources:
+          requests:
+            cpu: 0m
+        ports:
+        - name: influxdb-port
+          containerPort: 8086
+        volumeMounts:
+        - mountPath: /var/lib/influxdb/
+          name: database-volume
+      - name: create-dbs
+        image: quay.io/influxdb/influxdb:1.6
+        imagePullPolicy: "IfNotPresent"
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+
+          until influx -execute "CREATE USER $INFLUX_USERNAME WITH PASSWORD '$INFLUX_PASSWORD' WITH ALL PRIVILEGES;"; do
+            echo waiting for influxdb;
+            sleep 1;
+          done
+
+          if [[ "$INFLUX_DATABASE" != "" ]]; then
+            influx -execute "create database \"$INFLUX_DATABASE\""
+          fi
+
+          tail -f /dev/null
+        env:
+        - name: INFLUX_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database
+              name: {{ .Params.INFLUX_SECRET }}
+        - name: INFLUX_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: {{ .Params.INFLUX_SECRET }}
+        - name: INFLUX_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: {{ .Params.INFLUX_SECRET }}
+      volumes:
+      - name: database-volume
+        persistentVolumeClaim:
+          claimName: influxdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: influxdb
+  labels:
+    app: influxdb
+    instance: {{ .Name }}
+spec:
+  ports:
+  - name: influxdb
+    port: 8086
+    targetPort: influxdb-port
+  selector:
+    app: influxdb
+    instance: {{ .Name }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: influxdb
+  labels:
+    app: influxdb
+    instance: {{ .Name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "{{ .Params.DISK_SIZE }}"

--- a/repository/influxdb/tests/influxdb-install/00-assert.yaml
+++ b/repository/influxdb/tests/influxdb-install/00-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: influxdb-querier
+status:
+  succeeded: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: influxdb-influxdb
+status:
+  readyReplicas: 1

--- a/repository/influxdb/tests/influxdb-install/00-install.yaml
+++ b/repository/influxdb/tests/influxdb-install/00-install.yaml
@@ -1,0 +1,47 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: influxdb
+spec:
+  operatorVersion:
+    name: influxdb-0.1.0
+    namespace: default
+    kind: OperatorVersion
+  name: influxdb
+  parameters:
+    INFLUX_SECRET: influxdb
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: influxdb
+stringData:
+  database: mydb
+  username: root
+  password: test
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: influxdb-querier
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: do-query
+        image: quay.io/influxdb/influxdb:1.6
+        imagePullPolicy: "IfNotPresent"
+        # Influx CLI seems to not exit with a proper exit status based on query.
+        command:
+        - bash
+        - -c
+        - |
+          set -eux
+          INFLUX=$(influx -database=mydb -host=influxdb-influxdb -execute "insert hello,location=world value=4")
+          ! grep ERR <(echo $INFLUX)
+        env:
+        - name: INFLUX_USERNAME
+          value: root
+        - name: INFLUX_PASSWORD
+          value: test

--- a/repository/mysql/operator/params.yaml
+++ b/repository/mysql/operator/params.yaml
@@ -5,3 +5,6 @@ BACKUP_FILE:
   trigger: backup
 PASSWORD:
   default: "password"
+DATABASE:
+  default: "kudo"
+  description: "Database name to provision."

--- a/repository/mysql/operator/templates/backup.yaml
+++ b/repository/mysql/operator/templates/backup.yaml
@@ -16,7 +16,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mysqldump -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} kudo > /backups/{{ .Params.BACKUP_FILE }}"
+        - "mysqldump -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} {{ .Params.DATABASE }} > /backups/{{ .Params.BACKUP_FILE }}"
         volumeMounts:
         - name: backup-pv
           mountPath: /backups

--- a/repository/mysql/operator/templates/init.yaml
+++ b/repository/mysql/operator/templates/init.yaml
@@ -16,4 +16,4 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mysql -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} -e \"CREATE TABLE example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );\" {{ .Params.DATABASE }} "
+        - "mysql -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} -e \"CREATE TABLE IF NOT EXISTS example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );\" {{ .Params.DATABASE }} "

--- a/repository/mysql/operator/templates/init.yaml
+++ b/repository/mysql/operator/templates/init.yaml
@@ -16,4 +16,4 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mysql -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} -e \"CREATE TABLE example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );\" kudo "
+        - "mysql -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} -e \"CREATE TABLE example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );\" {{ .Params.DATABASE }} "

--- a/repository/mysql/operator/templates/mysql.yaml
+++ b/repository/mysql/operator/templates/mysql.yaml
@@ -45,7 +45,7 @@ spec:
         - name: MYSQL_ROOT_PASSWORD
           value: {{ .Params.PASSWORD }}
         - name: MYSQL_DATABASE
-          value: kudo
+          value: {{ .Params.DATABASE }}
         ports:
         - containerPort: 3306
           name: mysql

--- a/repository/mysql/operator/templates/restore.yaml
+++ b/repository/mysql/operator/templates/restore.yaml
@@ -16,7 +16,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mysql -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} --database=kudo < /backups/{{ .Params.BACKUP_FILE }}"
+        - "mysql -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} --database={{ .Params.DATABASE }} < /backups/{{ .Params.BACKUP_FILE }}"
         volumeMounts:
         - name: backup-pv
           mountPath: /backups

--- a/repository/mysql/tests/mysql-install/00-assert.yaml
+++ b/repository/mysql/tests/mysql-install/00-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: mysql-install
+status:
+  status: COMPLETE
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mysql-install-querier
+status:
+  succeeded: 1

--- a/repository/mysql/tests/mysql-install/00-install.yaml
+++ b/repository/mysql/tests/mysql-install/00-install.yaml
@@ -1,0 +1,23 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: mysql-install
+spec:
+  operatorVersion:
+    name: mysql-0.1.0
+    namespace: default
+    kind: OperatorVersion
+  name: mysql-install
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mysql-install-querier
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - image: mysql:5.7
+        name: mysql
+        command: [mysql, -ppassword, -h, mysql-install-mysql, -e, SELECT 1, kudo]

--- a/repository/mysql/tests/mysql-override-database/00-assert.yaml
+++ b/repository/mysql/tests/mysql-override-database/00-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: mysql-override-database
+status:
+  status: COMPLETE
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mysql-override-database-querier
+status:
+  succeeded: 1

--- a/repository/mysql/tests/mysql-override-database/00-install.yaml
+++ b/repository/mysql/tests/mysql-override-database/00-install.yaml
@@ -8,8 +8,8 @@ spec:
     namespace: default
     kind: OperatorVersion
   name: mysql-override-database
-parameters:
-  DATABASE: my-database
+  parameters:
+    DATABASE: my-database
 ---
 apiVersion: batch/v1
 kind: Job

--- a/repository/mysql/tests/mysql-override-database/00-install.yaml
+++ b/repository/mysql/tests/mysql-override-database/00-install.yaml
@@ -8,8 +8,8 @@ spec:
     namespace: default
     kind: OperatorVersion
   name: mysql-override-database
-  parameters:
-    DATABASE: my-database
+parameters:
+  DATABASE: my-database
 ---
 apiVersion: batch/v1
 kind: Job

--- a/repository/mysql/tests/mysql-override-database/00-install.yaml
+++ b/repository/mysql/tests/mysql-override-database/00-install.yaml
@@ -1,0 +1,25 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: mysql-override-database
+spec:
+  operatorVersion:
+    name: mysql-0.1.0
+    namespace: default
+    kind: OperatorVersion
+  name: mysql-override-database
+  parameters:
+    DATABASE: my-database
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mysql-override-database-querier
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - image: mysql:5.7
+        name: mysql
+        command: [mysql, -ppassword, -h, mysql-override-database-mysql, -e, SELECT 1, my-database]

--- a/repository/velodrome/README.md
+++ b/repository/velodrome/README.md
@@ -1,0 +1,3 @@
+# Velodrome operator
+
+Deploys a [Velodrome](https://github.com/kubernetes/test-infra/tree/master/velodrome) instance for collecting metrics from Github for [Prow](https://github.com/kubernetes/test-infra/tree/master/prow)

--- a/repository/velodrome/operator/operator.yaml
+++ b/repository/velodrome/operator/operator.yaml
@@ -1,0 +1,23 @@
+name: "velodrome"
+version: "0.1.0"
+kudoVersion: 0.5.0
+kubernetesVersion: 1.5.1
+maintainers:
+  - Justin Taylor-Barrick <jbarrick@d2iq.com>
+url: https://github.com/kubernetes/test-infra/tree/master/velodrome
+tasks:
+  deploy:
+    resources:
+      - fetcher.yaml
+      - sqlproxy.yaml
+      - transform.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: velodrome
+        strategy: parallel
+        steps:
+          - name: everything
+            tasks:
+              - deploy

--- a/repository/velodrome/operator/params.yaml
+++ b/repository/velodrome/operator/params.yaml
@@ -1,0 +1,36 @@
+REPOSITORIES:
+  description: Comma-delimited list of repositories to collect metrics for.
+  example: "kudobuilder/operators,kudobuilder/kudo"
+  required: true
+SQLPROXY_INSTANCES:
+  default: ""
+  description: Instances for the [SQL proxy](https://github.com/GoogleCloudPlatform/cloudsql-proxy) to connect to.
+MYSQL_HOSTNAME:
+  default: ""
+  description: Hostname of mysql to use. If not set, a sqlproxy instance will be provisioned.
+MYSQL_SECRET:
+  description: |
+    Name of secret containing MySQL connection settings.
+
+    This secret should have the following keys:
+
+      * database: The MySQL database to use.
+      * reader-user: The MySQL username to use when reading.
+      * reader-pass: The MySQL password to use when reading.
+      * writer-user: The MySQL username to use when writing.
+      * writer-pass: The MySQL password to use when writing.
+  required: true
+INFLUX_HOSTNAME:
+  description: Hostname of the influxdb instance to connect to.
+  required: true
+INFLUX_SECRET:
+  description: Name of secret containing credentials for influxdb. Should contain a `username`, `password`, and `database` key.
+  required: true
+GITHUB_SECRET:
+  description: Name of secret containing Github token.
+  required: true
+GITHUB_USERNAME:
+  description: Name of Github user used to collect metrics.
+GCS_SERVICE_ACCOUNT_SECRET:
+  description: Name of secret containing GCS service account token (should have a `credential.json` key).
+  required: true

--- a/repository/velodrome/operator/templates/fetcher.yaml
+++ b/repository/velodrome/operator/templates/fetcher.yaml
@@ -1,0 +1,77 @@
+{{ $this := . }}
+
+{{ range $repository := (splitList "," .Params.REPOSITORIES) }}
+
+{{ $org := (splitn "/" 2 $repository)._0 }}
+{{ $repo := (splitn "/" 2 $repository)._1 }}
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fetcher-{{ $org }}-{{ $repo }}
+  labels:
+    app: fetcher
+    instance: {{ $this.Name }}
+    org: {{ $org }}
+    repo: {{ $repo }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fetcher
+      instance: {{ $this.Name }}
+      org: {{ $org }}
+      repo: {{ $repo }}
+  template:
+    metadata:
+      labels:
+        app: fetcher
+        instance: {{ $this.Name }}
+        org: {{ $org }}
+        repo: {{ $repo }}
+    spec:
+      containers:
+      - name: fetcher
+        args:
+        - --organization={{ $org }}
+        - --project={{ $repo }}
+        - --token-file=/etc/secret-volume/{{ $this.Params.GITHUB_USERNAME }}
+        - --stderrthreshold=0
+        {{ if $this.Params.MYSQL_HOSTNAME }}
+        - --host={{ $this.Params.MYSQL_HOSTNAME }}
+        {{ else if $this.Params.SQLPROXY_INSTANCES }}
+        - --host={{ $this.Name }}-sqlproxy
+        {{ end }}
+        - --user=$(MYSQL_WRITER_USER)
+        - --password=$(MYSQL_WRITER_PASS)
+        - --database=$(MYSQL_DATABASE)
+        image: k8s.gcr.io/github-fetcher:v20170327-143731
+        resources:
+          requests:
+            cpu: 0m
+        volumeMounts:
+        - mountPath: /etc/secret-volume
+          readOnly: true
+          name: github-tokens-secret
+        env:
+        - name: MYSQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: {{ $this.Params.MYSQL_SECRET }}
+              key: database
+        - name: MYSQL_WRITER_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ $this.Params.MYSQL_SECRET }}
+              key: writer-user
+        - name: MYSQL_WRITER_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ $this.Params.MYSQL_SECRET }}
+              key: writer-pass
+      volumes:
+      - name: github-tokens-secret
+        secret:
+          secretName: {{ $this.Params.GITHUB_SECRET }}
+---
+{{ end }}

--- a/repository/velodrome/operator/templates/sqlproxy.yaml
+++ b/repository/velodrome/operator/templates/sqlproxy.yaml
@@ -1,0 +1,65 @@
+{{ if eq .Params.MYSQL_HOSTNAME "" }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: sqlproxy
+  labels:
+    app: sqlproxy
+    instance: {{ .Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sqlproxy
+      instance: {{ .Name }}
+  template:
+    metadata:
+      labels:
+        app: sqlproxy
+        instance: {{ .Name }}
+    spec:
+      containers:
+      - image: gcr.io/cloudsql-docker/gce-proxy:1.14
+        name: sqlproxy
+        command:
+        - /cloud_sql_proxy
+        - -dir=/cloudsql
+        - -credential_file=/credentials/credential.json
+        resources:
+          requests:
+            cpu: 0m
+        env:
+          - name: INSTANCES
+            value: {{ .Params.SQLPROXY_INSTANCES }}
+        ports:
+        - name: sqlproxy-port
+          containerPort: 3306
+        volumeMounts:
+        - mountPath: /cloudsql
+          name: cloudsql
+        - mountPath: /credentials
+          name: service-account-token
+          readOnly: true
+      volumes:
+      - name: cloudsql
+        emptyDir:
+      - name: service-account-token
+        secret:
+          secretName: {{ .Params.GCS_SERVICE_ACCOUNT_SECRET }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sqlproxy
+  labels:
+    app: sqlproxy
+    instance: {{ .Name }}
+spec:
+  ports:
+  - name: sqlport
+    port: 3306
+    targetPort: sqlproxy-port
+  selector:
+    app: sqlproxy
+    instance: {{ .Name }}
+{{ end }}

--- a/repository/velodrome/operator/templates/transform.yaml
+++ b/repository/velodrome/operator/templates/transform.yaml
@@ -1,0 +1,132 @@
+{{ $this := . }}
+
+{{ range $repository := (splitList "," .Params.REPOSITORIES) }}
+
+{{ $org := (splitn "/" 2 $repository)._0 }}
+{{ $repo := (splitn "/" 2 $repository)._1 }}
+
+{{ range $metric, $metricArgs := dict "contributions" `
+- --no-issues
+- --event=opened
+- --comments=.*
+- --log-author
+` "approved" `
+- --no-issues
+- --percentiles=50
+- --state=opened,!labeled:needs-rebase,labeled:approved
+` "lgtmed" `
+- --no-issues
+- --percentiles=50
+- --state=opened,!labeled:needs-rebase,labeled:lgtm
+` "merge" `
+- --no-issues
+- --event=merged
+` "open" `
+- --no-issues
+- --state=opened,!merged
+- --percentiles=50
+` "needs-rebase" `
+- --no-issues
+- --percentiles=50
+- --state=opened,labeled:needs-rebase
+` "lgtmer" `
+- --no-issues
+- --ignore-authors=k8s-merge-robot
+- --event=labeled:lgtm
+- --comments=(?m)^/lgtm$
+- --log-author
+` "testthis" `
+- --no-issues
+- --comments=(?m)^@k8s-bot.*test this
+` "approver" `
+- --no-issues
+- --event=labeled:approved
+- --comments=(?m)^/approve$
+- --log-author
+` }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: transform-{{ $org }}-{{ $repo }}-{{ $metric }}
+  labels:
+    app: transform
+    instance: {{ $this.Name }}
+    org: {{ $org }}
+    repo: {{ $repo }}
+    metric: {{ $metric }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: transform
+      instance: {{ $this.Name }}
+      org: {{ $org }}
+      repo: {{ $repo }}
+      metric: {{ $metric }}
+  template:
+    metadata:
+      labels:
+        app: transform
+        instance: {{ $this.Name }}
+        org: {{ $org }}
+        repo: {{ $repo }}
+        metric: {{ $metric }}
+    spec:
+      containers:
+      - args:
+        - --repository={{ $org }}/{{ $repo }}
+        - --stderrthreshold=0
+        {{ if $this.Params.MYSQL_HOSTNAME }}
+        - --host={{ $this.Params.MYSQL_HOSTNAME }}
+        {{ else }}
+        - --host={{ $this.Name }}-sqlproxy
+        {{ end }}
+        - --user=$(MYSQL_READER_USER)
+        - --password=$(MYSQL_READER_PASS)
+        - --database=$(MYSQL_DATABASE)
+        - --influx-host={{ $this.Params.INFLUX_HOSTNAME }}
+        - --influx-user=$(INFLUXDB_USER)
+        - --influx-password=$(INFLUXDB_PASSWORD)
+        - --influx-database=$(INFLUXDB_DATABASE)
+        - --name={{ $metric }}
+        - count
+        {{ indent 8 $metricArgs }}
+        env:
+        - name: INFLUXDB_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database
+              name: {{ $this.Params.INFLUX_SECRET }}
+        - name: INFLUXDB_USER
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: {{ $this.Params.INFLUX_SECRET }}
+        - name: INFLUXDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: {{ $this.Params.INFLUX_SECRET }}
+        - name: MYSQL_READER_USER
+          valueFrom:
+            secretKeyRef:
+              key: reader-user
+              name: {{ $this.Params.MYSQL_SECRET }}
+        - name: MYSQL_READER_PASS
+          valueFrom:
+            secretKeyRef:
+              key: reader-pass
+              name: {{ $this.Params.MYSQL_SECRET }}
+        - name: MYSQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database
+              name: {{ $this.Params.MYSQL_SECRET }}
+        image: k8s.gcr.io/github-transform:v20170323-155737
+        name: transform
+        resources:
+          requests:
+            cpu: 0m
+---
+{{ end }}
+{{ end }}

--- a/repository/velodrome/tests/velodrome-install/00-assert.yaml
+++ b/repository/velodrome/tests/velodrome-install/00-assert.yaml
@@ -1,0 +1,261 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-install-mysql
+status:
+  status: COMPLETE
+---
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-install-influxdb
+status:
+  status: COMPLETE
+---
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-install-velodrome
+status:
+  status: COMPLETE
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-influxdb-influxdb
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-mysql-mysql
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-fetcher-kudobuilder-kudo
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --organization=kudobuilder
+        - --project=kudo
+        - --token-file=/etc/secret-volume/test-user
+        - --stderrthreshold=0
+        - --host=velodrome-install-mysql-mysql
+        - --user=$(MYSQL_WRITER_USER)
+        - --password=$(MYSQL_WRITER_PASS)
+        - --database=$(MYSQL_DATABASE)
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-fetcher-kudobuilder-operators
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --organization=kudobuilder
+        - --project=operators
+        - --token-file=/etc/secret-volume/test-user
+        - --stderrthreshold=0
+        - --host=velodrome-install-mysql-mysql
+        - --user=$(MYSQL_WRITER_USER)
+        - --password=$(MYSQL_WRITER_PASS)
+        - --database=$(MYSQL_DATABASE)
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-kudo-approved
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --repository=kudobuilder/kudo
+        - --stderrthreshold=0
+        - --host=velodrome-install-mysql-mysql
+        - --user=$(MYSQL_READER_USER)
+        - --password=$(MYSQL_READER_PASS)
+        - --database=$(MYSQL_DATABASE)
+        - --influx-host=http://velodrome-install-influxdb-influxdb:8086
+        - --influx-user=$(INFLUXDB_USER)
+        - --influx-password=$(INFLUXDB_PASSWORD)
+        - --influx-database=$(INFLUXDB_DATABASE)
+        - --name=approved
+        - count
+        - --no-issues
+        - --percentiles=50
+        - --state=opened,!labeled:needs-rebase,labeled:approved
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-kudo-approver
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --repository=kudobuilder/kudo
+        - --stderrthreshold=0
+        - --host=velodrome-install-mysql-mysql
+        - --user=$(MYSQL_READER_USER)
+        - --password=$(MYSQL_READER_PASS)
+        - --database=$(MYSQL_DATABASE)
+        - --influx-host=http://velodrome-install-influxdb-influxdb:8086
+        - --influx-user=$(INFLUXDB_USER)
+        - --influx-password=$(INFLUXDB_PASSWORD)
+        - --influx-database=$(INFLUXDB_DATABASE)
+        - --name=approver
+        - count
+        - --no-issues
+        - --event=labeled:approved
+        - --comments=(?m)^/approve$
+        - --log-author
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-kudo-contributions
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-kudo-lgtmed
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-kudo-lgtmer
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-kudo-merge
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-kudo-needs-rebase
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-kudo-open
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-kudo-testthis
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-operators-approved
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --repository=kudobuilder/operators
+        - --stderrthreshold=0
+        - --host=velodrome-install-mysql-mysql
+        - --user=$(MYSQL_READER_USER)
+        - --password=$(MYSQL_READER_PASS)
+        - --database=$(MYSQL_DATABASE)
+        - --influx-host=http://velodrome-install-influxdb-influxdb:8086
+        - --influx-user=$(INFLUXDB_USER)
+        - --influx-password=$(INFLUXDB_PASSWORD)
+        - --influx-database=$(INFLUXDB_DATABASE)
+        - --name=approved
+        - count
+        - --no-issues
+        - --percentiles=50
+        - --state=opened,!labeled:needs-rebase,labeled:approved
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-operators-approver
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-operators-contributions
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-operators-lgtmed
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-operators-lgtmer
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-operators-merge
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-operators-needs-rebase
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-operators-open
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-install-velodrome-transform-kudobuilder-operators-testthis
+status:
+  readyReplicas: 1

--- a/repository/velodrome/tests/velodrome-install/00-install.yaml
+++ b/repository/velodrome/tests/velodrome-install/00-install.yaml
@@ -1,0 +1,72 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-install-mysql
+spec:
+  operatorVersion:
+    name: mysql-0.1.0
+    namespace: default
+    kind: OperatorVersion
+  name: velodrome-install-mysql
+  parameters:
+    DATABASE: github-mysql
+---
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-install-influxdb
+spec:
+  operatorVersion:
+    name: influxdb-0.1.0
+    namespace: default
+    kind: OperatorVersion
+  name: velodrome-install-influxdb
+  parameters:
+    INFLUX_SECRET: influxdb
+---
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-install-velodrome
+spec:
+  operatorVersion:
+    name: velodrome-0.1.0
+    namespace: default
+    kind: OperatorVersion
+  name: velodrome-install-velodrome
+  parameters:
+    REPOSITORIES: kudobuilder/operators,kudobuilder/kudo
+    GCS_SERVICE_ACCOUNT_SECRET: gcs-service-account
+    GITHUB_USERNAME: test-user
+    GITHUB_SECRET: github
+    INFLUX_HOSTNAME: http://velodrome-install-influxdb-influxdb:8086
+    INFLUX_SECRET: influxdb
+    MYSQL_HOSTNAME: velodrome-install-mysql-mysql
+    MYSQL_SECRET: mysql
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: influxdb
+stringData:
+  database: github-influxdb
+  username: root
+  password: test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql
+stringData:
+  database: github-mysql
+  reader-user: root
+  reader-pass: password
+  writer-user: root
+  writer-pass: password
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github
+stringData:
+  test-user: "1203912039124034123"

--- a/repository/velodrome/tests/velodrome-sqlproxy/00-assert.yaml
+++ b/repository/velodrome/tests/velodrome-sqlproxy/00-assert.yaml
@@ -1,0 +1,64 @@
+# This test is unable to actually verify that Velodrome works all the way in this configuration as we do not have a GCS account
+# available for the tests.
+# However, it verifies that sqlproxy is able to start and that all of the components are configured correctly to use it.
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-sqlproxy-velodrome
+---
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-sqlproxy-influxdb
+status:
+  status: COMPLETE
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-sqlproxy-velodrome-sqlproxy
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-sqlproxy-velodrome-fetcher-kudobuilder-kudo
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --organization=kudobuilder
+        - --project=kudo
+        - --token-file=/etc/secret-volume/test-user
+        - --stderrthreshold=0
+        - --host=velodrome-sqlproxy-velodrome-sqlproxy
+        - --user=$(MYSQL_WRITER_USER)
+        - --password=$(MYSQL_WRITER_PASS)
+        - --database=$(MYSQL_DATABASE)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velodrome-sqlproxy-velodrome-transform-kudobuilder-kudo-approved
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --repository=kudobuilder/kudo
+        - --stderrthreshold=0
+        - --host=velodrome-sqlproxy-velodrome-sqlproxy
+        - --user=$(MYSQL_READER_USER)
+        - --password=$(MYSQL_READER_PASS)
+        - --database=$(MYSQL_DATABASE)
+        - --influx-host=http://velodrome-sqlproxy-influxdb-influxdb:8086
+        - --influx-user=$(INFLUXDB_USER)
+        - --influx-password=$(INFLUXDB_PASSWORD)
+        - --influx-database=$(INFLUXDB_DATABASE)
+        - --name=approved
+        - count
+        - --no-issues
+        - --percentiles=50
+        - --state=opened,!labeled:needs-rebase,labeled:approved

--- a/repository/velodrome/tests/velodrome-sqlproxy/00-install.yaml
+++ b/repository/velodrome/tests/velodrome-sqlproxy/00-install.yaml
@@ -1,0 +1,80 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-sqlproxy-influxdb
+spec:
+  operatorVersion:
+    name: influxdb-0.1.0
+    namespace: default
+    kind: OperatorVersion
+  name: velodrome-sqlproxy-influxdb
+  parameters:
+    INFLUX_SECRET: influxdb
+---
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: velodrome-sqlproxy-velodrome
+spec:
+  operatorVersion:
+    name: velodrome-0.1.0
+    namespace: default
+    kind: OperatorVersion
+  name: velodrome-sqlproxy-velodrome
+  parameters:
+    REPOSITORIES: kudobuilder/kudo
+    GITHUB_USERNAME: test-user
+    GITHUB_SECRET: github
+    INFLUX_HOSTNAME: http://velodrome-sqlproxy-influxdb-influxdb:8086
+    INFLUX_SECRET: influxdb
+    SQLPROXY_INSTANCES: example-project:us-central1:velodrome-prow=tcp:0.0.0.0:3306
+    GCS_SERVICE_ACCOUNT_SECRET: gcs-service-account
+    MYSQL_SECRET: mysql
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: influxdb
+stringData:
+  database: github-influxdb
+  username: root
+  password: test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql
+stringData:
+  database: github-mysql
+  reader-user: root
+  reader-pass: password
+  writer-user: root
+  writer-pass: password
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github
+stringData:
+  test-user: "1203912039124034123"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcs-service-account
+type: Opaque
+stringData:
+  # Mocked data since sqlproxy wants to be able to parse it.
+  credential.json: |
+    {
+      "type": "service_account",
+      "project_id": "example-project",
+      "private_key_id": "f572d396fae9206628714fb2ce00f72e94f2258f",
+      "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEpAIBAAKCAQEAtOLxxcnse6SXckELCbIzzCSTtUQMscXfYiM3hResF3ryNcXk\ny34+jifW/LzBQVvyw9UgDqv6NJvHgdu408BY+5bgHhj3D4oG/stiDAKr4wbs7Lft\nHc4JO0H2dhF1vRn8aXECrAxuHVtPo3SVrAjbyjJOIfcUHD7wzRSxPAIWa8Do32RB\n3gvKN5H7G6W0XEfvbVme7GA01UOLk4ExveQ/otwn05bhEO22uyvwtdVYA4aA9hMQ\ng2U1cdWomQtZ/EquwDSa7KvCj1kmhUCIBRd4YmxwC+PCCIcAepETQ1rl1l9CmrNu\nHFQpj/lIxyK7PvfDDCi7cbuqaikMGqbgL6zzWQIDAQABAoIBAFR+cfs3AD0dPBUF\npvdHg4SHTWvttpRP3rHDy4pi7WMmbf+KSf54IRZcK8NxFEDIh5TMeCYCVWS/o6jY\nDvTys14KMvQ8KyPaELxyGoGLuejZclB89cjnVk6U2GB8dWf4vHwwatQdFk6mOYQb\n0FJE7Q39A5xAAufSyr6xPLzQKNL5xzuhSgGULvprCtqR+2JjBpH8TUTnf/7Pc+fq\noUNXCP5bIpwA7+azXObN0Vi7deHFf5wD3rxk3Jr8HAXV60DDV/VIXtscIwJtAV8M\nHOUzts+FNv7Av7WfIO/z+bqQqHn9oMrmW3HzotukkUqip+NuEnwWY1FgAqeFRekk\nk0WAcwECgYEA4uPcaMAXDh6yd1/XXI5qg6uwVKBWf/CuT9Q+3ZEpw/0s3knvRqJ5\nmMZ7Y/6VlmR2EobApm7jyLq8H8thnkd14W822sw30FKOpDdW31Kon6HweAtTOR5L\nDCdR0SqfRcT/xDU/43haKtgzlR5TxBBCbSekOLqgRf/ZH/ZLKMGGqDkCgYEAzBgb\n80jFLDuTv5houynwx8bjjsaGWZSiUrDLwYfm4GLxXiIfdG963mzAeHUUGWIoPpbD\nfl+jJGGYkYaf2RpjavGKEkivTU7t2bd59CYbFpLXe7Pu4nUE2Xba7ZTA2fj0KdKD\nZvr8vU3qrDtaR57ISRroev2GR+2lLrZLvaJzZCECgYEAzGac7R2IZ6cN/m8wVGjU\n2nQ08bhU1QPd9Xrve6pIJxGRd1zCHC9JPnIpPUdgOdGdcUlGi2nA+dgInNgbxHz6\nXLJVh72M1rdZW+Wi9KPB17YLLgp92ipJT9SoZ7hvLmqwRHH4cZO+H3UQ21kr+6ju\nPuoEjzrKIuXAFIRM55WZGzkCgYEAt1ddHHKdtbubYX1Pb/sgMscHOwY6QJTWMQRj\nNeqYy6/2dgKfUSCoNtFpIYzDTn4v+vHCkm7lhlQqE2jlhck/0B1FVGF5ITCrWG6L\nHnlw0hl9e8HK8iH/Bj/QMab0i5sp87wJkOQdUQ2Cp8/1rOsFry5986Z2D317avgW\nGDesAyECgYAVSCbfxAhsCMfMbAOrBYq+zuqPNn1xCZfelS7dWNHd8bgLmzI1PGF+\nFVOWbel9kI7BBOm79yku59RHg0iUmucPv1cddNZ1D/lFvmTsEcdkCDviEoiu/ZLp\nwus5DS4tdx5PdYA8dLWeu021Scrwpu89HHHXqm9ahuI0iOtUbpahMg==\n-----END PRIVATE KEY-----\n",
+      "client_email": "prowservice@example-project.iam.gserviceaccount.com",
+      "client_id": "12304912039401234",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/prowservice%40example-project.iam.gserviceaccount.com"
+    }


### PR DESCRIPTION
Velodrome is a service for collecting metrics about Github projects and Prow used for the Kubernetes test-infra: https://github.com/kubernetes/test-infra/tree/master/velodrome

We will use this operator in our KUDO Prow instance as well as elsewhere.

Velodrome depends on influxdb, so this also adds an influxdb operator.

Also adds tests and adds a `DATABASE` setting to MySQL that can be used to affect the database name used by MySQL.