### PR TITLE
kafka: update references from 0.1.1 to 0.1.2

### DIFF
--- a/repository/flink/docs/demo/financial-fraud/README.md
+++ b/repository/flink/docs/demo/financial-fraud/README.md
@@ -68,7 +68,7 @@ minikube start --vm-driver=hyperkit --cpus=6 --memory=9216 --disk-size=10g
         ```bash
         $ kubectl kudo install kafka --version=0.1.1 --skip-instance
         operator.kudo.dev/v1alpha1/kafka created
-        operatorversion.kudo.dev/v1alpha1/kafka-0.1.1 created
+        operatorversion.kudo.dev/v1alpha1/kafka-0.1.2 created
         ```
 - Have the `flink` Operator with `0.1.0` as OperatorVersion installed
     - Use the KUDO CLI with the following command:
@@ -138,7 +138,7 @@ Next, the Kafka operator will start its `deploy` plan, when completed we will se
 $ kubectl kudo plan status --instance flink-demo-kafka
 Plan(s) for "flink-demo-kafka" in namespace "default":
 .
-└── flink-demo-kafka (Operator-Version: "kafka-0.1.1" Active-Plan: "flink-demo-kafka-deploy-11918518")
+└── flink-demo-kafka (Operator-Version: "kafka-0.1.2" Active-Plan: "flink-demo-kafka-deploy-11918518")
     └── Plan deploy (serial strategy) [COMPLETE]
         └── Phase deploy-kafka (serial strategy) [COMPLETE]
             └── Step deploy (COMPLETE)

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/kafka.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/kafka.yaml
@@ -7,7 +7,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-0.1.1
+    name: kafka-0.1.2
     namespace: default
     type: OperatorVersions
   parameters:

--- a/repository/kafka/README.md
+++ b/repository/kafka/README.md
@@ -14,6 +14,6 @@ For the latest master branch you can check  [docs](./docs/latest) docs
 
 | KUDO Kafka Version | Apache Kafka Version |
 | ------------------ | -------------------- |
-| 0.1.1              | 2.2.1                |
+| 0.1.2              | 2.2.1                |
 | 0.2.0              | 2.3.0                |
 | latest             | 2.3.0                |

--- a/repository/kafka/docs/latest/install.md
+++ b/repository/kafka/docs/latest/install.md
@@ -26,7 +26,7 @@ Verify the if the deploy plan for `--instance=kafka` is complete.
 kubectl kudo plan status --instance=kafka
 Plan(s) for "kafka" in namespace "default":
 .
-└── kafka (Operator-Version: "kafka-0.1.1" Active-Plan: "kafka-deploy-177524647")
+└── kafka (Operator-Version: "kafka-0.1.2" Active-Plan: "kafka-deploy-177524647")
     └── Plan deploy (serial strategy) [COMPLETE]
         └── Phase deploy-kafka (serial strategy) [COMPLETE]
             └── Step deploy (COMPLETE)

--- a/repository/kafka/docs/latest/update.md
+++ b/repository/kafka/docs/latest/update.md
@@ -18,18 +18,14 @@ There are a few constraints related to storage. These constraints are documented
 Enable the `delete.topic.enable`
 
 ```
-> kubectl patch instance kafka -p '{"spec":{"parameters":{"DELETE_TOPIC_ENABLE":"true"}}}' --type=merge
-instance.kudo.k8s.io/kafka patched
+> kubectl kudo update kafka -p DELETE_TOPIC_ENABLE=true 
 ```
 
 Enable the `auto.create.topics.enable`
 
 ```
-> kubectl patch instance kafka -p '{"spec":{"parameters":{"AUTO_CREATE_TOPICS_ENABLE":"true"}}}' --type=merge
-instance.kudo.k8s.io/kafka patched
+> kubectl kudo update kafka -p  AUTO_CREATE_TOPICS_ENABLE=true
 ```
-
-
 
 ## Scaling the brokers
 
@@ -42,8 +38,7 @@ It is recommended that users closely monitor and control broker scaling due to t
 To scale horizontally, we can increase the broker count. Lets update the broker count from default `3` to `5`
 
 ```
-> kubectl patch instance kafka -p '{"spec":{"parameters":{"BROKER_COUNT":"5"}}}' --type=merge
-instance.kudo.k8s.io/kafka patched
+> kubectl kudo update kafka -p BROKER_COUNT=4
 ```
 
 Check the plan status:
@@ -102,7 +97,7 @@ To scale vertically, we can update the broker's statefulset.
 Let's increase the cpu request from `500m` to `700m` and double the memory request from `2048Mi` to `4096Mi`. Also important is increasing the limits as they cannot be lower than the requested resources. 
 
 ```
-kubectl patch instance kafka -p '{"spec":{"parameters":{"BROKER_CPUS":"700m", "BROKER_MEM":"4096Mi", "BROKER_CPUS_LIMIT":"3000m", "BROKER_MEM_LIMIT":"6144Mi"}}}' --type=merge
+kubectl kudo update kafka -p BROKER_CPUS=700m -p BROKER_MEM=4096Mi -p BROKER_CPUS_LIMIT=3000m -p BROKER_MEM_LIMIT=6144Mi
 ```
 
 This will initiate a rolling upgrade of the pods to a new statefulset.

--- a/repository/kafka/docs/latest/upgrade.md
+++ b/repository/kafka/docs/latest/upgrade.md
@@ -15,24 +15,7 @@ Upgrading can be done by patching the Kafka Instance that holds all the configur
 
 ![operator-upgrade-1](./resources/images/operator-upgrade-2.png)
 
-The following upgrade procedure assumes one running Kafka cluster and one Kafka operator version already installed (version `kafka-0.1.1`):
-
-Install a new operator version:
-
-```
-kubectl kudo install kafka --version=0.2.0 --skip-instance
-
-operator.kudo.dev/kafka unchanged
-operatorversion.kudo.dev/v1alpha1/kafka-0.2.0 created
-```
-Now there are two operator versions installed:
-```
-kubectl  get operatorversions.kudo.k8s.io
-
-NAME              AGE
-kafka-0.1.1       2d2h
-kafka-0.2.0       2m6s
-```
+The following upgrade procedure assumes one running Kafka cluster and one Kafka operator version already installed (version `kafka-0.1.2`). It also assumes one is running KUDO 0.5.0 or later:
 
 Check for running instances:
 
@@ -47,18 +30,28 @@ We can check the plan status of our Kafka cluster `kafka-fc6vzn` with:
 kubectl kudo plan status --instance=kafka-fc6vzn
 Plan(s) for "kafka-fc6vzn" in namespace "default":
 .
-└── kafka-fc6vzn (Operator-Version: "kafka-0.1.1" Active-Plan: "kafka-fc6vzn-deploy-414458000")
+└── kafka-fc6vzn (Operator-Version: "kafka-0.1.2" Active-Plan: "kafka-fc6vzn-deploy-414458000")
     └── Plan deploy (serial strategy) [COMPLETE]
         └── Phase deploy-kafka (serial strategy) [COMPLETE]
             └── Step deploy (COMPLETE)
 ```
-**Note:** the operator version is `kafka-0.1.1`
+**Note:** the operator version is `kafka-0.1.2`
 
-To update the Kafka cluster from version `0.1.1` to `0.2.0`:
+To update the Kafka cluster from version `0.1.2` to `0.2.0`:
 
 ```
-> kubectl patch instance kafka  -p '{"spec":{"operatorVersion":{"name":"kafka-0.2.0"}}}' --type=merge
-instance.kudo.k8s.io/kafka patched
+kubectl kudo upgrade kafka --version=0.2.0 --instance kafka
+
+operator.kudo.dev/kafka unchanged
+operatorversion.kudo.dev/v1alpha1/kafka-0.2.0 created
+```
+Now there are two operator versions installed:
+```
+kubectl  get operatorversions.kudo.k8s.io
+
+NAME              AGE
+kafka-0.1.2       2d2h
+kafka-0.2.0       2m6s
 ```
 
 Check the plan status again:

--- a/repository/kafka/docs/v0.1/install.md
+++ b/repository/kafka/docs/v0.1/install.md
@@ -23,7 +23,7 @@ Verify the if the deploy plan for `--instance=kafka` is complete.
 kubectl kudo plan status --instance=kafka
 Plan(s) for "kafka" in namespace "default":
 .
-└── kafka (Operator-Version: "kafka-0.1.1" Active-Plan: "kafka-deploy-177524647")
+└── kafka (Operator-Version: "kafka-0.1.2" Active-Plan: "kafka-deploy-177524647")
     └── Plan deploy (serial strategy) [COMPLETE]
         └── Phase deploy-kafka (serial strategy) [COMPLETE]
             └── Step deploy (COMPLETE)

--- a/repository/kafka/docs/v0.2/install.md
+++ b/repository/kafka/docs/v0.2/install.md
@@ -26,7 +26,7 @@ Verify the if the deploy plan for `--instance=kafka` is complete.
 kubectl kudo plan status --instance=kafka
 Plan(s) for "kafka" in namespace "default":
 .
-└── kafka (Operator-Version: "kafka-0.1.1" Active-Plan: "kafka-deploy-177524647")
+└── kafka (Operator-Version: "kafka-0.1.2" Active-Plan: "kafka-deploy-177524647")
     └── Plan deploy (serial strategy) [COMPLETE]
         └── Phase deploy-kafka (serial strategy) [COMPLETE]
             └── Step deploy (COMPLETE)

--- a/repository/kafka/docs/v0.2/update.md
+++ b/repository/kafka/docs/v0.2/update.md
@@ -18,18 +18,14 @@ There are a few constraints related to storage. These constraints are documented
 Enable the `delete.topic.enable`
 
 ```
-> kubectl patch instance kafka -p '{"spec":{"parameters":{"DELETE_TOPIC_ENABLE":"true"}}}' --type=merge
-instance.kudo.k8s.io/kafka patched
+> kubectl kudo update kafka -p DELETE_TOPIC_ENABLE=true 
 ```
 
 Enable the `auto.create.topics.enable`
 
 ```
-> kubectl patch instance kafka -p '{"spec":{"parameters":{"AUTO_CREATE_TOPICS_ENABLE":"true"}}}' --type=merge
-instance.kudo.k8s.io/kafka patched
+> kubectl kudo update kafka -p  AUTO_CREATE_TOPICS_ENABLE=true
 ```
-
-
 
 ## Scaling the brokers
 
@@ -42,8 +38,7 @@ It is recommended that users closely monitor and control broker scaling due to t
 To scale horizontally, we can increase the broker count. Lets update the broker count from default `3` to `5`
 
 ```
-> kubectl patch instance kafka -p '{"spec":{"parameters":{"BROKER_COUNT":"5"}}}' --type=merge
-instance.kudo.k8s.io/kafka patched
+> kubectl kudo update kafka -p BROKER_COUNT=4
 ```
 
 Check the plan status:
@@ -102,7 +97,7 @@ To scale vertically, we can update the broker's statefulset.
 Let's increase the cpu request from `500m` to `700m` and double the memory request from `2048Mi` to `4096Mi`. Also important is increasing the limits as they cannot be lower than the requested resources. 
 
 ```
-kubectl patch instance kafka -p '{"spec":{"parameters":{"BROKER_CPUS":"700m", "BROKER_MEM":"4096Mi", "BROKER_CPUS_LIMIT":"3000m", "BROKER_MEM_LIMIT":"6144Mi"}}}' --type=merge
+kubectl kudo update kafka -p BROKER_CPUS=700m -p BROKER_MEM=4096Mi -p BROKER_CPUS_LIMIT=3000m -p BROKER_MEM_LIMIT=6144Mi
 ```
 
 This will initiate a rolling upgrade of the pods to a new statefulset.

--- a/repository/kafka/docs/v0.2/upgrade.md
+++ b/repository/kafka/docs/v0.2/upgrade.md
@@ -15,7 +15,7 @@ Upgrading can be done by patching the Kafka Instance that holds all the configur
 
 ![operator-upgrade-1](./resources/images/operator-upgrade-2.png)
 
-The following upgrade procedure assumes one running Kafka cluster and one Kafka operator version already installed (version `kafka-0.1.1`). It also assumes one is running KUDO 0.5.0 or later:
+The following upgrade procedure assumes one running Kafka cluster and one Kafka operator version already installed (version `kafka-0.1.2`). It also assumes one is running KUDO 0.5.0 or later:
 
 Check for running instances:
 
@@ -30,12 +30,12 @@ We can check the plan status of our Kafka cluster `kafka-fc6vzn` with:
 kubectl kudo plan status --instance=kafka-fc6vzn
 Plan(s) for "kafka-fc6vzn" in namespace "default":
 .
-└── kafka-fc6vzn (Operator-Version: "kafka-0.1.1" Active-Plan: "kafka-fc6vzn-deploy-414458000")
+└── kafka-fc6vzn (Operator-Version: "kafka-0.1.2" Active-Plan: "kafka-fc6vzn-deploy-414458000")
     └── Plan deploy (serial strategy) [COMPLETE]
         └── Phase deploy-kafka (serial strategy) [COMPLETE]
             └── Step deploy (COMPLETE)
 ```
-**Note:** the operator version is `kafka-0.1.1`
+**Note:** the operator version is `kafka-0.1.2`
 
 To update the Kafka cluster from version `0.1.1` to `0.2.0`:
 
@@ -50,7 +50,7 @@ Now there are two operator versions installed:
 kubectl  get operatorversions.kudo.k8s.io
 
 NAME              AGE
-kafka-0.1.1       2d2h
+kafka-0.1.2       2d2h
 kafka-0.2.0       2m6s
 ```
 

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -1,7 +1,8 @@
 name: "kafka"
-version: "0.2.0"
-kudoVersion: 0.4.0
+version: "0.2.1"
+kudoVersion: 0.5.0
 kubernetesVersion: 1.15.0
+appVersion: "2.3.0"
 maintainers:
   - Zain Malik <zmalikshxil@gmail.com>
 url: https://kafka.apache.org/


### PR DESCRIPTION
This PR

- removes references to `0.1.1` version of Kafka operator that was removed as we released a `0.1.2`
- update docs of KUDO Kafka on how-to update instance using `update` command of `KUDO` cli 
- bumps master to version `0.2.1` for next release