### PR TITLE
Kafka: add advanced health checks

### DIFF
--- a/repository/kafka/docs/latest/configuration.md
+++ b/repository/kafka/docs/latest/configuration.md
@@ -21,6 +21,17 @@ kubectl kudo install kafka --instance=my-kafka-name \
           
 ```
 
+##### Health Checks
+
+By default, the Kafka operator will use livenessProbe of type tcpSocket to check the broker port. This is a simple port based health check.
+
+For using a more robust health check based on broker functionality you can set the parameter `LIVENESS_METHOD` to `FUNCTIONAL`. 
+This check is a producer-consumer check based on a custom heartbeat topic which you can set using the parameter `LIVENESS_TOPIC_PREFIX`.
+
+```
+kubectl kudo install kafka --instance=my-kafka-name -p LIVENESS_METHOD=FUNCTIONAL -p LIVENESS_TOPIC_PREFIX=MyHealthCheckTopic
+```
+
 ##### Storage
 
 By default, the Kafka operator will use the default storage class of the Kubernetes cluster. 

--- a/repository/kafka/docs/latest/release-notes.md
+++ b/repository/kafka/docs/latest/release-notes.md
@@ -2,6 +2,9 @@
 
 ## latest
 
+- Exposed configuration for livenessProbe and readinessProbe
+- User can enable advanced service health checks. Option to choose between a simple port-based check and an advanced producer-consumer check based on a custom heartbeat topic.
+
 ## v0.2.0 
 July 30th, 2019
 

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -13,6 +13,7 @@ tasks:
       - pdb.yaml
       - configmap.yaml
       - metrics-config.yaml
+      - health-check.yaml
       - statefulset.yaml
   update:
     resources:
@@ -20,6 +21,7 @@ tasks:
     - pdb.yaml
     - configmap.yaml
     - metrics-config.yaml
+    - health-check.yaml
     - statefulset.yaml
   not-allowed:
     resources:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -104,13 +104,33 @@ LEADER_IMBALANCE_PER_BROKER_PERCENTAGE:
 
 LIVENESS_INITIAL_DELAY_SECONDS:
   displayName: "livenessProbe initial delay timeout seconds"
-  description: "livenessProbe initial delay in seconds"
+  description: "Number of seconds after the container has started before liveness probes is initiated."
   default: "30"
 
 LIVENESS_PERIOD_SECONDS:
   displayName: "livenessProbe period seconds"
-  description: "livenessProbe period in seconds"
+  description: "How often (in seconds) to perform the probe. Default to 30 seconds. Minimum value is 1."
   default: "30"
+
+LIVENESS_TIMEOUT_SECONDS:
+  displayName: "livenessProbe timeout seconds"
+  description: "Number of seconds after which the probe times out. Defaults to 30 seconds. Minimum value is 1."
+  default: "30"
+
+LIVENESS_FAILURE_THRESHOLD:
+  displayName: "livenessProbe timeout seconds"
+  description: "When the Pod starts and the probe fails, Kubernetes will try failureThreshold times before restarting the Pod. Defaults to 3. Minimum value is 1."
+  default: "3"
+
+LIVENESS_METHOD:
+  displayName: "livenessProbe method"
+  description: "livenessProbe method values 'PORT' or 'FUNCTIONAL'"
+  default: "PORT"
+
+LIVENESS_TOPIC_PREFIX:
+  displayName: "livenessProbe topic prefix"
+  description: "This topic is used by livenessProbe when 'FUNCTIONAL' method is selected."
+  default: "LivenessProbeTopicPrefix"
 
 LOG_FLUSH_INTERVAL_MESSAGES:
   default: "9223372036854775807"
@@ -288,10 +308,30 @@ QUOTA_PRODUCER_DEFAULT:
   description: "Used only when dynamic default quotas are not configured for , or in Zookeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second"
   default: "9223372036854775807"
 
+READINESS_INITIAL_DELAY_SECONDS:
+  displayName: "livenessProbe initial delay timeout seconds"
+  description: "Number of seconds after the container has started before liveness probes is initiated. Defaults to 10."
+  default: "10"
+
+READINESS_PERIOD_SECONDS:
+  displayName: "livenessProbe period seconds"
+  description: "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1."
+  default: "10"
+
 READINESS_TIMEOUT_SECONDS:
   displayName: "readinessProbe timeout seconds"
-  description: "readinessProbe timeout in seconds"
+  description: "Number of seconds after which the probe times out. Defaults to 30 seconds. Minimum value is 1."
   default: "30"
+
+READINESS_SUCCESS_THRESHOLD:
+  displayName: "livenessProbe timeout seconds"
+  description: "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Minimum value is 1."
+  default: "1"
+
+READINESS_FAILURE_THRESHOLD:
+  displayName: "livenessProbe timeout seconds"
+  description: "When a Pod starts and the probe fails, Kubernetes will try failureThreshold times before the Pod will be marked Unready. Defaults to 3. Minimum value is 1."
+  default: "3"
 
 REPLICA_FETCH_MAX_BYTES:
   displayName: "replica.fetch.max.bytes"

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -130,7 +130,7 @@ LIVENESS_METHOD:
 LIVENESS_TOPIC_PREFIX:
   displayName: "livenessProbe topic prefix"
   description: "This topic is used by livenessProbe when 'FUNCTIONAL' method is selected."
-  default: "LivenessProbeTopicPrefix"
+  default: "KafkaLivenessTopic"
 
 LOG_FLUSH_INTERVAL_MESSAGES:
   default: "9223372036854775807"

--- a/repository/kafka/operator/templates/health-check.yaml
+++ b/repository/kafka/operator/templates/health-check.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+data:
+  health-check.sh: |
+    #!/usr/bin/env bash
+    
+    set -e
+    
+    POD_INSTANCE_INDEX=${HOSTNAME##*-}
+    KAFKA_BROKER_ADDRESS=$HOSTNAME
+    KAFKA_BROKER_PORT=$KAFKA_BROKER_PORT
+    KAFKA_HEALTH_CHECK_TOPIC_PREFIX={{ .Params.LIVENESS_TOPIC_PREFIX }}
+
+    if ! ${KAFKA_HOME}/bin/kafka-topics.sh --list --zookeeper $KAFKA_ZK_URI | grep -q ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX}
+    then
+      ${KAFKA_HOME}/bin/kafka-topics.sh --create \
+        --zookeeper $KAFKA_ZK_URI --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} \
+        --replica-assignment $POD_INSTANCE_INDEX 2>&1
+    fi
+    
+    # Create a random message
+    random_message=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '')
+    echo $random_message > /tmp/kafka_health_check_msg
+  
+    # Publish the message to topic
+    if [ $( ${KAFKA_HOME}/bin/kafka-console-producer.sh \
+      --broker-list ${KAFKA_BROKER_ADDRESS}:${KAFKA_BROKER_PORT} \
+      --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} 2>&1 < /tmp/kafka_health_check_msg | grep -c ">>" ) -ne 1 ]
+    then
+      echo "Health check falied as the message cannot be published! topic: ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} msg: $random_message"
+      exit 1
+    fi
+  
+    # Get the number of messages in the topic
+    message_count=$(${KAFKA_HOME}/bin/kafka-run-class.sh kafka.tools.GetOffsetShell \
+      --broker-list $KAFKA_BROKER_ADDRESS:$KAFKA_BROKER_PORT \
+      --partitions 0 --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} | awk -F: '{print $NF}')
+  
+    # Check if the last message is the one we published
+    if ${KAFKA_HOME}/bin/kafka-console-consumer.sh \
+      --bootstrap-server $KAFKA_BROKER_ADDRESS:$KAFKA_BROKER_PORT \
+      --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} \
+      --offset $(( message_count - 1 )) \
+      --partition 0 --max-messages 1 | grep -q $random_message
+    then
+      echo "Health check passed! topic: ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} msg: $random_message"
+      exit 0
+    else
+      echo "Health check falied due to message mismatch! topic: ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} msg: $random_message"
+      exit 1
+    fi
+
+kind: ConfigMap
+metadata:
+  name: health-check-script

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -37,7 +37,7 @@ spec:
           command:
             - sh
             - -c
-            - "exec $KAFKA_HOME/bin/start-kafka.sh"
+            - "cp /health-check-script/health-check.sh health-check.sh; chmod +x health-check.sh; exec $KAFKA_HOME/bin/start-kafka.sh"
           env:
             - name: KAFKA_HEAP_OPTS
               value : "-Xmx512M -Xms512M"
@@ -72,6 +72,8 @@ spec:
           {{ end }}
             - name: config
               mountPath: /config
+            - name: health-check-script
+              mountPath: /health-check-script
           {{ if eq .Params.METRICS_ENABLED "true" }}
             - name: metrics
               mountPath: /metrics
@@ -82,15 +84,26 @@ spec:
                 - sh
                 - -c
                 - "$KAFKA_HOME/readiness-check.sh"
+            initialDelaySeconds: {{ .Params.READINESS_INITIAL_DELAY_SECONDS }}
+            periodSeconds: {{ .Params.READINESS_PERIOD_SECONDS }}
             timeoutSeconds: {{ .Params.READINESS_TIMEOUT_SECONDS }}
+            successThreshold: {{ .Params.READINESS_SUCCESS_THRESHOLD }}
+            failureThreshold: {{ .Params.READINESS_FAILURE_THRESHOLD }}
           livenessProbe:
+            {{ if eq .Params.LIVENESS_METHOD "FUNCTIONAL" }}
             exec:
               command:
               - sh
               - -c
-              - "$KAFKA_HOME/readiness-check.sh"
+              - "$KAFKA_HOME/health-check.sh"
+            {{ else }}
+            tcpSocket:
+              port: {{ .Params.BROKER_PORT }}
+            {{ end }}
             initialDelaySeconds: {{ .Params.LIVENESS_INITIAL_DELAY_SECONDS }}
             periodSeconds: {{ .Params.LIVENESS_PERIOD_SECONDS }}
+            timeoutSeconds: {{ .Params.LIVENESS_TIMEOUT_SECONDS }}
+            failureThreshold: {{ .Params.LIVENESS_FAILURE_THRESHOLD }}
       securityContext:
         runAsUser: 1000
         fsGroup: 1000
@@ -101,6 +114,9 @@ spec:
         - name: metrics
           configMap:
             name: {{ .Name }}-metrics-config
+        - name: health-check-script
+          configMap:
+            name: {{ .Name }}-health-check-script
   volumeClaimTemplates:
     {{ if eq .Params.PERSISTENT_STORAGE "true" }}
     - metadata:


### PR DESCRIPTION
This PR

- Exposes all configuration for `livenssProbe` and `readinessProbe` for the `k8skafka` container
- Adds two ways of doing health checks (livenssProbe) for the `k8skafka` container:  a simple port based health check using a TCP liveness probe, and an advanced producer-consumer functional check based on a custom heartbeat topic.
- Updates release notes and configuration documentation.