### PR TITLE
zookeeper: change image and add some params

### DIFF
--- a/repository/zookeeper/operator/operator.yaml
+++ b/repository/zookeeper/operator/operator.yaml
@@ -1,6 +1,6 @@
 name: "zookeeper"
-version: "0.1.0"
-kudoVersion: 0.3.0
+version: "0.2.0"
+kudoVersion: 0.5.0
 kubernetesVersion: 1.15.0
 maintainers:
   - Alena Varkockova <avarkockova@mesosphere.com>
@@ -9,6 +9,8 @@ url: https://zookeeper.apache.org/
 tasks:
   infra:
     resources:
+      - bootstrap.sh.yaml
+      - healthcheck.sh.yaml
       - services.yaml
       - pdb.yaml
   app:
@@ -24,7 +26,7 @@ plans:
       - name: zookeeper
         strategy: parallel
         steps:
-          - name: everything
+          - name: deploy
             tasks:
               - infra
               - app

--- a/repository/zookeeper/operator/operator.yaml
+++ b/repository/zookeeper/operator/operator.yaml
@@ -1,6 +1,7 @@
 name: "zookeeper"
 version: "0.2.0"
 kudoVersion: 0.5.0
+appVersion: 3.4.14
 kubernetesVersion: 1.15.0
 maintainers:
   - Alena Varkockova <avarkockova@mesosphere.com>

--- a/repository/zookeeper/operator/params.yaml
+++ b/repository/zookeeper/operator/params.yaml
@@ -16,7 +16,7 @@ STORAGE_CLASS:
   required: false
 
 DISK_SIZE:
-  description: "Disk size for the brokers"
+  description: "Disk size for the Zookeeper servers"
   default: "5Gi"
 
 CLIENT_PORT:

--- a/repository/zookeeper/operator/params.yaml
+++ b/repository/zookeeper/operator/params.yaml
@@ -1,6 +1,36 @@
-memory:
+NODE_COUNT:
+  description: "Number of nodes spun up for Zookeeper"
+  default: 3
+  displayName: "Node Count"
+
+MEMORY:
   description: Amount of memory to provide to Zookeeper pods
   default: "1Gi"
-cpus:
+
+CPUS:
   description: Amount of cpu to provide to Zookeeper pods
   default: "0.25"
+
+STORAGE_CLASS:
+  description: "The storage class to be used in volumeClaimTemplates. By default its not required and the default storage class is used."
+  required: false
+
+DISK_SIZE:
+  description: "Disk size for the brokers"
+  default: "5Gi"
+
+CLIENT_PORT:
+  default: "2181"
+  description: |
+    The port on which the Zookeeper process will listen for client requests. The default is 2181.
+
+SERVER_PORT:
+  default: "2888"
+  description: |
+    The port on which the Zookeeper process will listen for requests from other servers in the ensemble.
+    The default is 2888.
+
+ELECTION_PORT:
+  description: |
+    The port on which the Zookeeper process will perform leader election. The default is 3888.
+  default: "3888"

--- a/repository/zookeeper/operator/templates/bootstrap.sh.yaml
+++ b/repository/zookeeper/operator/templates/bootstrap.sh.yaml
@@ -1,0 +1,322 @@
+apiVersion: v1
+data:
+  bootstrap.sh: |
+    #!/usr/bin/env bash
+    # Copyright 2017 The Kubernetes Authors.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    #
+    #
+    #Usage: start-zookeeper [OPTIONS]
+    # Starts a ZooKeeper server based on the supplied options.
+    #     --servers           The number of servers in the ensemble. The default
+    #                         value is 1.
+
+    #     --data_dir          The directory where the ZooKeeper process will store its
+    #                         snapshots. The default is /var/lib/zookeeper/data.
+
+    #     --data_log_dir      The directory where the ZooKeeper process will store its
+    #                         write ahead log. The default is
+    #                         /var/lib/zookeeper/data/log.
+
+    #     --conf_dir          The directoyr where the ZooKeeper process will store its
+    #                         configuration. The default is /opt/zookeeper/conf.
+
+    #     --client_port       The port on which the ZooKeeper process will listen for
+    #                         client requests. The default is 2181.
+
+    #     --election_port     The port on which the ZooKeeper process will perform
+    #                         leader election. The default is 3888.
+
+    #     --server_port       The port on which the ZooKeeper process will listen for
+    #                         requests from other servers in the ensemble. The
+    #                         default is 2888.
+
+    #     --tick_time         The length of a ZooKeeper tick in ms. The default is
+    #                         2000.
+
+    #     --init_limit        The number of Ticks that an ensemble member is allowed
+    #                         to perform leader election. The default is 10.
+
+    #     --sync_limit        The maximum session timeout that the ensemble will
+    #                         allows a client to request. The default is 5.
+
+    #     --heap              The maximum amount of heap to use. The format is the
+    #                         same as that used for the Xmx and Xms parameters to the
+    #                         JVM. e.g. --heap=2G. The default is 2G.
+
+    #     --max_client_cnxns  The maximum number of client connections that the
+    #                         ZooKeeper process will accept simultaneously. The
+    #                         default is 60.
+
+    #     --snap_retain_count The maximum number of snapshots the ZooKeeper process
+    #                         will retain if purge_interval is greater than 0. The
+    #                         default is 3.
+
+    #     --purge_interval    The number of hours the ZooKeeper process will wait
+    #                         between purging its old snapshots. If set to 0 old
+    #                         snapshots will never be purged. The default is 0.
+
+    #     --max_session_timeout The maximum time in milliseconds for a client session
+    #                         timeout. The default value is 2 * tick time.
+
+    #     --min_session_timeout The minimum time in milliseconds for a client session
+    #                         timeout. The default value is 20 * tick time.
+
+    #     --log_level         The log level for the zookeeeper server. Either FATAL,
+    #                         ERROR, WARN, INFO, DEBUG. The default is INFO.
+
+
+    USER=`whoami`
+    HOST=`hostname -s`
+    DOMAIN=`hostname -d`
+    LOG_LEVEL=INFO
+    DATA_DIR="/var/lib/zookeeper/data"
+    DATA_LOG_DIR="/var/lib/zookeeper/log"
+    LOG_DIR="/logs"
+    CONF_DIR="/conf"
+    CLIENT_PORT={{ .Params.CLIENT_PORT }}
+    SERVER_PORT={{ .Params.SERVER_PORT }}
+    ELECTION_PORT={{ .Params.ELECTION_PORT }}
+    TICK_TIME=2000
+    INIT_LIMIT=10
+    SYNC_LIMIT=5
+    HEAP=2G
+    MAX_CLIENT_CNXNS=60
+    SNAP_RETAIN_COUNT=3
+    PURGE_INTERVAL=0
+    SERVERS=1
+
+    function print_usage() {
+    echo "\
+    Usage: start-zookeeper [OPTIONS]
+    Starts a ZooKeeper server based on the supplied options.
+        --servers           The number of servers in the ensemble. The default
+                            value is 1.
+        --data_dir          The directory where the ZooKeeper process will store its
+                            snapshots. The default is /var/lib/zookeeper/data.
+        --data_log_dir      The directory where the ZooKeeper process will store its
+                            write ahead log. The default is
+                            /var/lib/zookeeper/data/log.
+        --conf_dir          The directoyr where the ZooKeeper process will store its
+                            configuration. The default is /opt/zookeeper/conf.
+        --client_port       The port on which the ZooKeeper process will listen for
+                            client requests. The default is 2181.
+        --election_port     The port on which the ZooKeeper process will perform
+                            leader election. The default is 3888.
+        --server_port       The port on which the ZooKeeper process will listen for
+                            requests from other servers in the ensemble. The
+                            default is 2888.
+        --tick_time         The length of a ZooKeeper tick in ms. The default is
+                            2000.
+        --init_limit        The number of Ticks that an ensemble member is allowed
+                            to perform leader election. The default is 10.
+        --sync_limit        The maximum session timeout that the ensemble will
+                            allows a client to request. The default is 5.
+        --heap              The maximum amount of heap to use. The format is the
+                            same as that used for the Xmx and Xms parameters to the
+                            JVM. e.g. --heap=2G. The default is 2G.
+        --max_client_cnxns  The maximum number of client connections that the
+                            ZooKeeper process will accept simultaneously. The
+                            default is 60.
+        --snap_retain_count The maximum number of snapshots the ZooKeeper process
+                            will retain if purge_interval is greater than 0. The
+                            default is 3.
+        --purge_interval    The number of hours the ZooKeeper process will wait
+                            between purging its old snapshots. If set to 0 old
+                            snapshots will never be purged. The default is 0.
+        --max_session_timeout The maximum time in milliseconds for a client session
+                            timeout. The default value is 2 * tick time.
+        --min_session_timeout The minimum time in milliseconds for a client session
+                            timeout. The default value is 20 * tick time.
+        --log_level         The log level for the zookeeeper server. Either FATAL,
+                            ERROR, WARN, INFO, DEBUG. The default is INFO.
+    "
+    }
+
+    function create_data_dirs() {
+        if [ ! -d $DATA_DIR  ]; then
+            mkdir -p $DATA_DIR
+            chown -R $USER:$USER $DATA_DIR
+        fi
+
+        if [ ! -d $DATA_LOG_DIR  ]; then
+            mkdir -p $DATA_LOG_DIR
+            chown -R $USER:$USER $DATA_LOG_DIR
+        fi
+
+        if [ ! -d $CONF_DIR  ]; then
+             mkdir -p $CONF_DIR
+             chown -R $USER:$USER $CONF_DIR
+        fi
+
+        if [ ! -d $LOG_DIR  ]; then
+            mkdir -p $LOG_DIR
+            chown -R $USER:$USER $LOG_DIR
+        fi
+        if [ ! -f $ID_FILE ] && [ $SERVERS -gt 1 ]; then
+            echo $MY_ID >> $ID_FILE
+        fi
+    }
+
+    function print_servers() {
+        for (( i=1; i<=$SERVERS; i++ ))
+        do
+            echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT"
+        done
+    }
+
+    function create_config() {
+        rm -f $CONFIG_FILE
+        echo "Zookeeper configuration..." >> $CONFIG_FILE
+        echo "clientPort=$CLIENT_PORT" >> $CONFIG_FILE
+        echo "dataDir=$DATA_DIR" >> $CONFIG_FILE
+        echo "dataLogDir=$DATA_LOG_DIR" >> $CONFIG_FILE
+        echo "tickTime=$TICK_TIME" >> $CONFIG_FILE
+        echo "initLimit=$INIT_LIMIT" >> $CONFIG_FILE
+        echo "syncLimit=$SYNC_LIMIT" >> $CONFIG_FILE
+        echo "maxClientCnxns=$MAX_CLIENT_CNXNS" >> $CONFIG_FILE
+        echo "minSessionTimeout=$MIN_SESSION_TIMEOUT" >> $CONFIG_FILE
+        echo "maxSessionTimeout=$MAX_SESSION_TIMEOUT" >> $CONFIG_FILE
+        echo "autopurge.snapRetainCount=$SNAP_RETAIN_COUNT" >> $CONFIG_FILE
+        echo "autopurge.purgeInteval=$PURGE_INTERVAL" >> $CONFIG_FILE
+         if [ $SERVERS -gt 1 ]; then
+            print_servers >> $CONFIG_FILE
+        fi
+        cat $CONFIG_FILE >&2
+    }
+
+    function create_jvm_props() {
+        rm -f $JAVA_ENV_FILE
+        echo "ZOO_LOG_DIR=$LOG_DIR" >> $JAVA_ENV_FILE
+        echo "JVMFLAGS=\"-Xmx$HEAP -Xms$HEAP\"" >> $JAVA_ENV_FILE
+    }
+
+    function create_log_props() {
+        rm -f $LOGGER_PROPS_FILE
+        echo "Creating ZooKeeper log4j configuration"
+        echo "zookeeper.root.logger=CONSOLE,ROLLINGFILE" >> $LOGGER_PROPS_FILE
+        echo "zookeeper.console.threshold="$LOG_LEVEL >> $LOGGER_PROPS_FILE
+        echo "zookeeper.log.dir="$LOG_DIR >> $LOGGER_PROPS_FILE
+        echo "log4j.rootLogger=\${zookeeper.root.logger}" >> $LOGGER_PROPS_FILE
+        echo "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender" >> $LOGGER_PROPS_FILE
+        echo "log4j.appender.CONSOLE.Threshold=\${zookeeper.console.threshold}" >> $LOGGER_PROPS_FILE
+        echo "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout" >> $LOGGER_PROPS_FILE
+        echo "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n" >> $LOGGER_PROPS_FILE
+        echo "log4j.appender.ROLLINGFILE.File=\${zookeeper.log.dir}/zookeeper.log" >> $LOGGER_PROPS_FILE
+        echo "log4j.appender.ROLLINGFILE.MaxFileSize=10MB" >> $LOGGER_PROPS_FILE
+        echo "log4j.appender.ROLLINGFILE.MaxBackupIndex=10" >> $LOGGER_PROPS_FILE
+    }
+
+    optspec=":hv-:"
+    while getopts "$optspec" optchar; do
+
+        case "${optchar}" in
+            -)
+                case "${OPTARG}" in
+                    servers=*)
+                        SERVERS=${OPTARG##*=}
+                        ;;
+                    data_dir=*)
+                        DATA_DIR=${OPTARG##*=}
+                        ;;
+                    data_log_dir=*)
+                        DATA_LOG_DIR=${OPTARG##*=}
+                        ;;
+                    log_dir=*)
+                        LOG_DIR=${OPTARG##*=}
+                        ;;
+                    conf_dir=*)
+                        CONF_DIR=${OPTARG##*=}
+                        ;;
+                    client_port=*)
+                        CLIENT_PORT=${OPTARG##*=}
+                        ;;
+                    election_port=*)
+                        ELECTION_PORT=${OPTARG##*=}
+                        ;;
+                    server_port=*)
+                        SERVER_PORT=${OPTARG##*=}
+                        ;;
+                    tick_time=*)
+                        TICK_TIME=${OPTARG##*=}
+                        ;;
+                    init_limit=*)
+                        INIT_LIMIT=${OPTARG##*=}
+                        ;;
+                    sync_limit=*)
+                        SYNC_LIMIT=${OPTARG##*=}
+                        ;;
+                    heap=*)
+                        HEAP=${OPTARG##*=}
+                        ;;
+                    max_client_cnxns=*)
+                        MAX_CLIENT_CNXNS=${OPTARG##*=}
+                        ;;
+                    snap_retain_count=*)
+                        SNAP_RETAIN_COUNT=${OPTARG##*=}
+                        ;;
+                    purge_interval=*)
+                        PURGE_INTERVAL=${OPTARG##*=}
+                        ;;
+                    max_session_timeout=*)
+                        MAX_SESSION_TIMEOUT=${OPTARG##*=}
+                        ;;
+                    min_session_timeout=*)
+                        MIN_SESSION_TIMEOUT=${OPTARG##*=}
+                        ;;
+                    log_level=*)
+                        LOG_LEVEL=${OPTARG##*=}
+                        ;;
+                    *)
+                        echo "Unknown option --${OPTARG}" >&2
+                        exit 1
+                        ;;
+                esac;;
+            h)
+                print_usage
+                exit
+                ;;
+            v)
+                echo "Parsing option: '-${optchar}'" >&2
+                ;;
+            *)
+                if [ "$OPTERR" != 1 ] || [ "${optspec:0:1}" = ":" ]; then
+                    echo "Non-option argument: '-${OPTARG}'" >&2
+                fi
+                ;;
+        esac
+    done
+    export PATH=$PATH:$ZOOKEEPERPATH/bin
+    MIN_SESSION_TIMEOUT=${MIN_SESSION_TIMEOUT:- $((TICK_TIME*2))}
+    MAX_SESSION_TIMEOUT=${MAX_SESSION_TIMEOUT:- $((TICK_TIME*20))}
+    ID_FILE="$DATA_DIR/myid"
+    CONFIG_FILE="$CONF_DIR/zoo.cfg"
+    LOGGER_PROPS_FILE="$CONF_DIR/log4j.properties"
+    JAVA_ENV_FILE="$CONF_DIR/java.env"
+    if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+        NAME=${BASH_REMATCH[1]}
+        ORD=${BASH_REMATCH[2]}
+    else
+        echo "Failed to parse name and ordinal of Pod"
+        exit 1
+    fi
+
+    MY_ID=$((ORD+1))
+
+    create_data_dirs && create_config && create_jvm_props && create_log_props && exec zkServer.sh start-foreground
+
+
+kind: ConfigMap
+metadata:
+  name: bootstrap

--- a/repository/zookeeper/operator/templates/bootstrap.sh.yaml
+++ b/repository/zookeeper/operator/templates/bootstrap.sh.yaml
@@ -178,7 +178,7 @@ data:
 
     function create_config() {
         rm -f $CONFIG_FILE
-        echo "Zookeeper configuration..." >> $CONFIG_FILE
+        echo "Zookeeper configuration..."
         echo "clientPort=$CLIENT_PORT" >> $CONFIG_FILE
         echo "dataDir=$DATA_DIR" >> $CONFIG_FILE
         echo "dataLogDir=$DATA_LOG_DIR" >> $CONFIG_FILE

--- a/repository/zookeeper/operator/templates/bootstrap.sh.yaml
+++ b/repository/zookeeper/operator/templates/bootstrap.sh.yaml
@@ -179,18 +179,22 @@ data:
     function create_config() {
         rm -f $CONFIG_FILE
         echo "Zookeeper configuration..."
-        echo "clientPort=$CLIENT_PORT" >> $CONFIG_FILE
-        echo "dataDir=$DATA_DIR" >> $CONFIG_FILE
-        echo "dataLogDir=$DATA_LOG_DIR" >> $CONFIG_FILE
-        echo "tickTime=$TICK_TIME" >> $CONFIG_FILE
-        echo "initLimit=$INIT_LIMIT" >> $CONFIG_FILE
-        echo "syncLimit=$SYNC_LIMIT" >> $CONFIG_FILE
-        echo "maxClientCnxns=$MAX_CLIENT_CNXNS" >> $CONFIG_FILE
-        echo "minSessionTimeout=$MIN_SESSION_TIMEOUT" >> $CONFIG_FILE
-        echo "maxSessionTimeout=$MAX_SESSION_TIMEOUT" >> $CONFIG_FILE
-        echo "autopurge.snapRetainCount=$SNAP_RETAIN_COUNT" >> $CONFIG_FILE
-        echo "autopurge.purgeInteval=$PURGE_INTERVAL" >> $CONFIG_FILE
-         if [ $SERVERS -gt 1 ]; then
+        tee $CONFIG_FILE <<EOF >/dev/null
+
+    clientPort=$CLIENT_PORT
+    dataDir=$DATA_DIR
+    dataLogDir=$DATA_LOG_DIR
+    tickTime=$TICK_TIME
+    initLimit=$INIT_LIMIT
+    syncLimit=$SYNC_LIMIT
+    maxClientCnxns=$MAX_CLIENT_CNXNS
+    minSessionTimeout=$MIN_SESSION_TIMEOUT
+    maxSessionTimeout=$MAX_SESSION_TIMEOUT
+    autopurge.snapRetainCount=$SNAP_RETAIN_COUNT
+    autopurge.purgeInteval=$PURGE_INTERVAL
+
+    EOF
+        if [ $SERVERS -gt 1 ]; then
             print_servers >> $CONFIG_FILE
         fi
         cat $CONFIG_FILE >&2
@@ -205,17 +209,22 @@ data:
     function create_log_props() {
         rm -f $LOGGER_PROPS_FILE
         echo "Creating ZooKeeper log4j configuration"
-        echo "zookeeper.root.logger=CONSOLE,ROLLINGFILE" >> $LOGGER_PROPS_FILE
-        echo "zookeeper.console.threshold="$LOG_LEVEL >> $LOGGER_PROPS_FILE
-        echo "zookeeper.log.dir="$LOG_DIR >> $LOGGER_PROPS_FILE
-        echo "log4j.rootLogger=\${zookeeper.root.logger}" >> $LOGGER_PROPS_FILE
-        echo "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender" >> $LOGGER_PROPS_FILE
-        echo "log4j.appender.CONSOLE.Threshold=\${zookeeper.console.threshold}" >> $LOGGER_PROPS_FILE
-        echo "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout" >> $LOGGER_PROPS_FILE
-        echo "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n" >> $LOGGER_PROPS_FILE
-        echo "log4j.appender.ROLLINGFILE.File=\${zookeeper.log.dir}/zookeeper.log" >> $LOGGER_PROPS_FILE
-        echo "log4j.appender.ROLLINGFILE.MaxFileSize=10MB" >> $LOGGER_PROPS_FILE
-        echo "log4j.appender.ROLLINGFILE.MaxBackupIndex=10" >> $LOGGER_PROPS_FILE
+        tee $LOGGER_PROPS_FILE <<EOF >/dev/null
+
+    zookeeper.root.logger=CONSOLE,ROLLINGFILE
+    zookeeper.console.threshold=$LOG_LEVEL
+    zookeeper.log.dir=$LOG_DIR
+    log4j.rootLogger=\${zookeeper.root.logger}
+    log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+    log4j.appender.CONSOLE.Threshold=\${zookeeper.console.threshold}
+    log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+    log4j.appender.CONSOLE.layout.ConversionPattern="%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n"
+    log4j.appender.ROLLINGFILE.File=\${zookeeper.log.dir}/zookeeper.log
+    log4j.appender.ROLLINGFILE.MaxFileSize=10MB
+    log4j.appender.ROLLINGFILE.MaxBackupIndex=10
+
+    EOF
+
     }
 
     optspec=":hv-:"

--- a/repository/zookeeper/operator/templates/healthcheck.sh.yaml
+++ b/repository/zookeeper/operator/templates/healthcheck.sh.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+data:
+  healthcheck.sh: |
+    #!/usr/bin/env bash
+    # Copyright 2017 The Kubernetes Authors.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    # zkOk.sh uses the ruok ZooKeeper four letter work to determine if the instance
+    # is health. The $? variable will be set to 0 if server responds that it is
+    # healthy, or 1 if the server fails to respond.
+
+    OK=$(echo ruok | nc 127.0.0.1 $1)
+    if [ "$OK" == "imok" ]; then
+    	exit 0
+    else
+    	exit 1
+    fi
+
+kind: ConfigMap
+metadata:
+  name: healthcheck

--- a/repository/zookeeper/operator/templates/services.yaml
+++ b/repository/zookeeper/operator/templates/services.yaml
@@ -8,9 +8,9 @@ metadata:
     zookeeper: {{ .Name }}
 spec:
   ports:
-    - port: 2888
+    - port: {{ .Params.SERVER_PORT }}
       name: server
-    - port: 3888
+    - port: {{ .Params.ELECTION_PORT }}
       name: leader-election
   clusterIP: None
   selector:
@@ -27,7 +27,7 @@ metadata:
     zookeeper: {{ .Name }}
 spec:
   ports:
-    - port: 2181
+    - port: {{ .Params.CLIENT_PORT }}
       name: client
   selector:
     app: zookeeper

--- a/repository/zookeeper/operator/templates/statefulset.yaml
+++ b/repository/zookeeper/operator/templates/statefulset.yaml
@@ -38,7 +38,7 @@ spec:
               name: client
             - containerPort: {{ .Params.SERVER_PORT }}
               name: server
-            - containerPort: 3888
+            - containerPort: {{ .Params.ELECTION_PORT }}
               name: leader-election
           command:
             - sh

--- a/repository/zookeeper/operator/templates/statefulset.yaml
+++ b/repository/zookeeper/operator/templates/statefulset.yaml
@@ -14,7 +14,7 @@ spec:
       zookeeper: {{ .OperatorName }}
       instance: {{ .Name }}
   serviceName: {{ .Name }}-hs
-  replicas: 3
+  replicas: {{ .Params.NODE_COUNT }}
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
@@ -28,29 +28,29 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: Always
-          image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+          image: "zookeeper:3.4.14"
           resources:
             requests:
-              memory: "{{ .Params.memory }}"
-              cpu: "{{ .Params.cpus }}"
+              memory: "{{ .Params.MEMORY }}"
+              cpu: "{{ .Params.CPUS }}"
           ports:
-            - containerPort: 2181
+            - containerPort: {{ .Params.CLIENT_PORT }}
               name: client
-            - containerPort: 2888
+            - containerPort: {{ .Params.SERVER_PORT }}
               name: server
             - containerPort: 3888
               name: leader-election
           command:
             - sh
             - -c
-            - "start-zookeeper \
+            - "ZOOKEEPERPATH=`pwd` /etc/zookeeper/bootstrap.sh \
               --servers=3 \
               --data_dir=/var/lib/zookeeper/data \
-              --data_log_dir=/var/lib/zookeeper/data/log \
-              --conf_dir=/opt/zookeeper/conf \
-              --client_port=2181 \
-              --election_port=3888 \
-              --server_port=2888 \
+              --data_log_dir=/logs \
+              --conf_dir=/conf \
+              --client_port={{ .Params.CLIENT_PORT }} \
+              --election_port={{ .Params.ELECTION_PORT }} \
+              --server_port={{ .Params.SERVER_PORT }} \
               --tick_time=2000 \
               --init_limit=10 \
               --sync_limit=5 \
@@ -66,7 +66,7 @@ spec:
               command:
                 - sh
                 - -c
-                - "zookeeper-ready 2181"
+                - "/etc/healthcheck/healthcheck.sh {{ .Params.CLIENT_PORT }}"
             initialDelaySeconds: 10
             timeoutSeconds: 5
           livenessProbe:
@@ -74,20 +74,37 @@ spec:
               command:
                 - sh
                 - -c
-                - "zookeeper-ready 2181"
+                - "/etc/healthcheck/healthcheck.sh {{ .Params.CLIENT_PORT }}"
             initialDelaySeconds: 10
             timeoutSeconds: 5
+            periodSeconds: 30
           volumeMounts:
             - name: datadir
               mountPath: /var/lib/zookeeper
+            - name: bootstrap
+              mountPath: /etc/zookeeper
+            - name: healthcheck
+              mountPath: /etc/healthcheck
       securityContext:
         runAsUser: 1000
         fsGroup: 1000
+      volumes:
+      - name: bootstrap
+        configMap:
+          name: {{ .Name }}-bootstrap
+          defaultMode: 0777
+      - name: healthcheck
+        configMap:
+          name: {{ .Name }}-healthcheck
+          defaultMode: 0777
   volumeClaimTemplates:
-    - metadata:
-        name: datadir
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 2Gi
+  - metadata:
+      name: datadir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Params.DISK_SIZE }}
+      {{ if .Params.STORAGE_CLASS }}
+      storageClassName: {{ .Params.STORAGE_CLASS }}
+      {{ end }}

--- a/repository/zookeeper/operator/templates/validation.yaml
+++ b/repository/zookeeper/operator/templates/validation.yaml
@@ -11,15 +11,15 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: Always
-          image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+          image: "zookeeper:3.4.14"
           env:
             - name: CONN
-              value: {{ .Name }}-zookeeper-0.{{ .Name }}-hs:2181,{{ .Name }}-zookeeper-1.{{ .Name }}-hs:2181,{{ .Name }}-zookeeper-2.{{ .Name }}-hs:2181
+              value: {{ .Name }}-zookeeper-0.{{ .Name }}-hs:{{ .Params.CLIENT_PORT }},{{ .Name }}-zookeeper-1.{{ .Name }}-hs:{{ .Params.CLIENT_PORT }},{{ .Name }}-zookeeper-2.{{ .Name }}-hs:{{ .Params.CLIENT_PORT }}
           resources:
             requests:
-              memory: "{{ .Params.memory }}"
-              cpu: "{{ .Params.cpus }}"
+              memory: "{{ .Params.MEMORY }}"
+              cpu: "{{ .Params.CPUS }}"
           command:
             - bash
             - -c
-            - "until /opt/zookeeper/bin/zkCli.sh -server $CONN ls /; do sleep 5; done"
+            - "until bin/zkCli.sh -server $CONN ls /; do sleep 5; done"

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/00-install.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/00-install.yaml
@@ -4,10 +4,10 @@ metadata:
   name: zk
 spec:
   operatorVersion:
-    name: zookeeper-0.1.0
+    name: zookeeper-0.2.0
     namespace: default
     kind: OperatorVersion
   name: "zk"
   parameters:
-    memory: "256Mi"
-    cpus: "0.3"
+    MEMORY: "256Mi"
+    CPUS: "0.3"

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/01-resize.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/01-resize.yaml
@@ -4,10 +4,10 @@ metadata:
   name: zk
 spec:
   operatorVersion:
-    name: zookeeper-0.1.0
+    name: zookeeper-0.2.0
     namespace: default
     kind: OperatorVersion
   name: "zk"
   parameters:
-    memory: "256Mi"
-    cpus: "0.2"
+    MEMORY: "256Mi"
+    CPUS: "0.2"


### PR DESCRIPTION
This PR:

- use official zookeeper image
- bumps to zk version `3.4.14`
- add few parameters necessary to tune the size/capacity of the zk cluster
- place necessary bootstrap/healthcheck scripts as `CM`
- bumps zk operator version to `0.2.0` for future release 
- use rolling logs limited to the size of 10MB and max 10 files to avoid any overflow on disk caused by logs
