### PR TITLE
Kafka Kerberos and AuthZ

### DIFF
--- a/repository/kafka/docs/latest/configuration.md
+++ b/repository/kafka/docs/latest/configuration.md
@@ -31,6 +31,16 @@ This check is a producer-consumer check based on a custom heartbeat topic which 
 ```
 kubectl kudo install kafka --instance=my-kafka-name -p LIVENESS_METHOD=FUNCTIONAL -p LIVENESS_TOPIC_PREFIX=MyHealthCheckTopic
 ```
+###### Using Kerberos with health checks
+
+Health checks can be enabled when using [Kerberos with KUDO Kafka](security.md). 
+When using `FUNCTIONAL` method then additional principals needs to be  created. Assuming `livenessProbe` as the principal name the principals will be: 
+```
+livenessProbe/kafka-kafka-0.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+livenessProbe/kafka-kafka-1.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+livenessProbe/kafka-kafka-2.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+```
+You need to create one principal per broker for each individual livenessProbe.
 
 ##### Storage
 

--- a/repository/kafka/docs/latest/security.md
+++ b/repository/kafka/docs/latest/security.md
@@ -1,0 +1,86 @@
+# Security
+
+## Authentication
+
+KUDO Kafka currently supports Kerberos authentication.
+
+### Kerberos Authentication
+
+Kerberos authentication relies on a central authority to verify that Kafka clients (be it broker, consumer, or producer) are who they say they are. KUDO Kafka integrates with your existing Kerberos infrastructure to verify the identity of clients.
+
+#### Prerequisites
+
+* The hostname and port of a KDC reachable from the inside of k8s cluster
+* Sufficient access to the KDC to create Kerberos principals
+* Sufficient access to the KDC to retrieve a keytab for the generated principals
+* `kubectl` installed
+
+#### Configure Kerberos Authentication
+
+##### Create principals
+
+The KUDO Kafka service requires a Kerberos principal for each broker to be deployed. Each principal must be of the form
+```
+<service primary>/kafka-kafka-<broker index>.kafka-svc.<namespace>.svc.cluster.local@<service realm>
+```
+with:
+* ```service primary = KERBEROS_PRIMARY```
+* ```broker index = 0 up to BROKER_COUNT - 1```
+* ```namespace = kubernetes namespace```
+* ```service realm = KERBEROS_REALM```
+
+For example, if installing with these options:
+```
+kubectl kudo install kafka \
+  --instance=kafka --namespace=kudo-kafka \
+    -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
+    -p KERBEROS_ENABLED=true \
+    -p KERBEROS_DEBUG=false\
+    -p KERBEROS_PRIMARY=kafka\
+    -p KERBEROS_REALM=LOCAL\
+    -p KERBEROS_KDC_HOSTNAME=kdc-service.kudo-kafka.svc.cluster.local \
+    -p KERBEROS_KDC_PORT=2500 \
+    -p KERBEROS_KEYTAB_SECRET="base64-kafka-keytab-secret"
+```
+then the principals to create would be:
+```
+kafka/kafka-kafka-0.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+kafka/kafka-kafka-1.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+kafka/kafka-kafka-2.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+```
+#### Place Service Keytab in Kubernetes Secret Store
+
+The KUDO Kafka service uses a keytab containing all node principals (service keytab). After creating the principals above, generate the service keytab making sure to include all the node principals. This should be stored as a secret in the Kubernetes Secret Store using `base64` encoding.
+
+## Authorization
+
+The KUDO Kafka service supports Kafka’s ACL-based authorization system. To use Kafka’s ACLs, Kerberos authentication must be enabled as detailed above.
+
+### Enable Authorization
+
+#### Prerequisites
+
+* Completion of Kerberos authentication above.
+
+### Install the Service
+
+Install the KUDO Kafka service with the following options in addition to your own (remember, Kerberos must be enabled):
+
+```
+kubectl kudo install kafka \
+  --instance=kafka --namespace=kudo-kafka \
+    -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
+    -p BROKER_COUNT=3 \
+    -p KERBEROS_ENABLED=true \
+    -p KERBEROS_DEBUG=false \
+    -p KERBEROS_PRIMARY=kafka\
+    -p KERBEROS_REALM=LOCAL\
+    -p KERBEROS_KEYTAB_SECRET="base64-kafka-keytab-secret"
+    -p AUTHORIZATION_ENABLED=<true|false default false> \
+    -p AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND=<true|false default false> \
+    -p AUTHORIZATION_SUPER_USERS="User:User1"
+```
+
+The format of the list is User:user1;User:user2;.... Using Kerberos authentication, the “user” value is the Kerberos primary. The Kafka brokers themselves are automatically designated as super users.
+
+>NOTE: It is possible to enable Authorization after initial installation, but the service may be unavailable during the transition. Additionally, Kafka clients may fail to function if they do not have the correct ACLs assigned to their principals. During the transition `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` can be set to `true` to prevent clients from being failing until their ACLs can be set correctly. After the transition, `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` should be reversed to `false`

--- a/repository/kafka/docs/latest/security.md
+++ b/repository/kafka/docs/latest/security.md
@@ -81,6 +81,6 @@ kubectl kudo install kafka \
     -p AUTHORIZATION_SUPER_USERS="User:User1"
 ```
 
-The format of the list is User:user1;User:user2;.... Using Kerberos authentication, the “user” value is the Kerberos primary. The Kafka brokers themselves are automatically designated as super users.
+The format of the list is `User:user1;User:user2;....` Using Kerberos authentication, the “user” value is the Kerberos primary. The Kafka brokers themselves are automatically designated as super users.
 
->NOTE: It is possible to enable Authorization after initial installation, but the service may be unavailable during the transition. Additionally, Kafka clients may fail to function if they do not have the correct ACLs assigned to their principals. During the transition `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` can be set to `true` to prevent clients from being failing until their ACLs can be set correctly. After the transition, `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` should be reversed to `false`
+NOTE: It is possible to enable Authorization after initial installation but the service may become unavailable during the transition. Additionally, Kafka clients may fail to function if they do not have the correct ACLs assigned to their principals. During the transition `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` can be set to `true` to prevent clients from failing until their ACLs can be set correctly. After the transition, `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` should be reset back to `false`.

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -11,17 +11,23 @@ tasks:
     resources:
       - service.yaml
       - pdb.yaml
-      - configmap.yaml
+      - server.properties.yaml
+      - bootstrap.yaml
       - metrics-config.yaml
       - health-check.yaml
+      - jaas-config.yaml
+      - krb5-config.yaml
       - statefulset.yaml
   update:
     resources:
     - service.yaml
     - pdb.yaml
-    - configmap.yaml
+    - server.properties.yaml
+    - bootstrap.yaml
     - metrics-config.yaml
     - health-check.yaml
+    - jaas-config.yaml
+    - krb5-config.yaml
     - statefulset.yaml
   not-allowed:
     resources:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -136,7 +136,7 @@ KERBEROS_REALM:
 
 KERBEROS_KDC_HOSTNAME:
   description: "The name or address of a host running a KDC for the realm."
-  default: "kdc-service.kudo-kafka.svc.cluster.local"
+  default: "kdc-service"
   displayName: "Kerberos Hostname"
 
 KERBEROS_KDC_PORT:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -1,6 +1,6 @@
 AUTHORIZATION_ENABLED:
   description: "Enable authorization."
-  default: false
+  default: "false"
   displayName: "Authorization Enabled"
 
 AUTHORIZATION_SUPER_USERS:
@@ -10,32 +10,8 @@ AUTHORIZATION_SUPER_USERS:
 
 AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND:
   description: "Allow any user to perform an action if no ACL is found for the resource."
-  default: false
-  displayName: "Allow everyone if no acl found"
-
-KERBEROS_ENABLED:
-  default: "true"
-
-KERBEROS_ENABLED_FOR_ZOOKEEPER:
   default: "false"
-
-KERBEROS_PRIMARY:
-  default: "kafka"
-
-KERBEROS_KEYTAB_SECRET:
-  default: "mysecret"
-
-KERBEROS_REALM:
-  default: "LOCAL"
-
-KERBEROS_KDC_HOSTNAME:
-  default: "kdc-service.kudo-kafka.svc.cluster.local"
-
-KERBEROS_KDC_PORT:
-  default: "2500"
-
-KERBEROS_DEBUG:
-  default: "true"
+  displayName: "Allow everyone if no acl found"
 
 BROKER_COUNT:
   description: "Number of brokers spun up for Kafka"
@@ -133,6 +109,46 @@ DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS:
   default: "1"
   description: "The purge interval (in number of requests) of the delete records request purgatory"
 
+KERBEROS_ENABLED:
+  description: "Enable kerberos authentication."
+  default: "true"
+  displayName: "Kerberos Enabled"
+
+KERBEROS_ENABLED_FOR_ZOOKEEPER:
+  description: "Enable Kerberos authentication for communication with Apache Zookeeper."
+  default: "false"
+  displayName: "Zookeeper Kerberos Enabled"
+
+KERBEROS_PRIMARY:
+  description: "The Kerberos primary used by Kafka tasks."
+  default: "kafka"
+  displayName: "Kerberos Primary"
+
+KERBEROS_KEYTAB_SECRET:
+  description: "The name of the Kubernetes secret storing the keytab."
+  default: "base64-kafka-keytab-secret"
+  displayName: "Kerberos Keytab Secret"
+
+KERBEROS_REALM:
+  description: "The Kerberos realm used to render the principal of Kafka broker pods."
+  default: "LOCAL"
+  displayName: "Kerberos Realm"
+
+KERBEROS_KDC_HOSTNAME:
+  description: "The name or address of a host running a KDC for the realm."
+  default: "kdc-service.kudo-kafka.svc.cluster.local"
+  displayName: "Kerberos Hostname"
+
+KERBEROS_KDC_PORT:
+  description: "The port of the host running a KDC for that realm."
+  default: "2500"
+  displayName: "Kerberos Port"
+
+KERBEROS_DEBUG:
+  description: "Turn debug Kerberos logging on or off to assist in diagnosing issues with Kerberos authentication."
+  default: "true"
+  displayName: "Kerberos Debug"
+
 LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS:
   default: "300"
   description: "The frequency with which the partition rebalance check is triggered by the controller"
@@ -173,6 +189,8 @@ LIVENESS_TOPIC_PREFIX:
 
 LIVENESS_KERBEROS_PRIMARY:
   default: "livenessProbe"
+  description: "The Kerberos primary used by the liveness probe when using FUNCTIONAL livenessProbe method."
+  displayName: "Liveness Probe Kerberos Primary"
 
 LOG_FLUSH_INTERVAL_MESSAGES:
   default: "9223372036854775807"

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -111,7 +111,7 @@ DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS:
 
 KERBEROS_ENABLED:
   description: "Enable kerberos authentication."
-  default: "true"
+  default: "false"
   displayName: "Kerberos Enabled"
 
 KERBEROS_ENABLED_FOR_ZOOKEEPER:
@@ -146,7 +146,7 @@ KERBEROS_KDC_PORT:
 
 KERBEROS_DEBUG:
   description: "Turn debug Kerberos logging on or off to assist in diagnosing issues with Kerberos authentication."
-  default: "true"
+  default: "false"
   displayName: "Kerberos Debug"
 
 LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -1,3 +1,42 @@
+AUTHORIZATION_ENABLED:
+  description: "Enable authorization."
+  default: false
+  displayName: "Authorization Enabled"
+
+AUTHORIZATION_SUPER_USERS:
+  description: "Semi-colon delimited list of principals. For Kerberos principals, these will be of the form User:<Kerberos-Primary>. For TLS, they will be of the form User:<CN of TLS cert> (for the TLS cert CN=test-user,OU=,O=Confluent,L=London,ST=London,C=GB, the user would be test-user)"
+  default: ""
+  displayName: "Super Users"
+
+AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND:
+  description: "Allow any user to perform an action if no ACL is found for the resource."
+  default: false
+  displayName: "Allow everyone if no acl found"
+
+KERBEROS_ENABLED:
+  default: "true"
+
+KERBEROS_ENABLED_FOR_ZOOKEEPER:
+  default: "false"
+
+KERBEROS_PRIMARY:
+  default: "kafka"
+
+KERBEROS_KEYTAB_SECRET:
+  default: "mysecret"
+
+KERBEROS_REALM:
+  default: "LOCAL"
+
+KERBEROS_KDC_HOSTNAME:
+  default: "kdc-service.kudo-kafka.svc.cluster.local"
+
+KERBEROS_KDC_PORT:
+  default: "2500"
+
+KERBEROS_DEBUG:
+  default: "true"
+
 BROKER_COUNT:
   description: "Number of brokers spun up for Kafka"
   default: "3"
@@ -131,6 +170,9 @@ LIVENESS_TOPIC_PREFIX:
   displayName: "livenessProbe topic prefix"
   description: "This topic is used by livenessProbe when 'FUNCTIONAL' method is selected."
   default: "KafkaLivenessTopic"
+
+LIVENESS_KERBEROS_PRIMARY:
+  default: "livenessProbe"
 
 LOG_FLUSH_INTERVAL_MESSAGES:
   default: "9223372036854775807"

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+data:
+  bootstrap.sh: |
+    #!/usr/bin/env bash
+
+    cp /health-check-script/health-check.sh health-check.sh;
+    chmod +x health-check.sh;
+
+    {{ if eq .Params.KERBEROS_ENABLED "true" }}
+    
+    cat /kafka-keytab/kafka.keytab | base64 --decode > kafka.keytab;
+    cp /jass-config/kafka_server_jaas.conf $KAFKA_HOME/config/kafka_server_jaas.conf;
+    cp /krb5-config/krb5.conf $KAFKA_HOME/config/krb5.conf;
+    sed -i "s/<HOSTNAME>/$(hostname -f)/g" $KAFKA_HOME/config/kafka_server_jaas.conf;
+    export KAFKA_OPTS="-Djava.security.auth.login.config=${KAFKA_HOME}/config/kafka_server_jaas.conf -Djava.security.krb5.conf=${KAFKA_HOME}/config/krb5.conf $KAFKA_OPTS"
+    
+    {{ if eq .Params.KERBEROS_DEBUG "true" }}
+    export KAFKA_OPTS="-Dsun.security.krb5.debug=true $KAFKA_OPTS"
+    {{ end }}
+    
+    {{ end }}
+    
+    KAFKA_BROKER_ID=${HOSTNAME##*-}
+    
+    # LISTENERS CONFIGURATION
+    LISTENERS="INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}"
+    # ADVERTISED LISTENERS
+    ADVERTISED_LISTENERS="INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}"
+    {{ if eq .Params.KERBEROS_ENABLED "true" }}
+      LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_PLAINTEXT"
+      # INTER_BROKER_SECURITY_PROTOCOL="SASL_PLAINTEXT"
+    {{ else }}
+      LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:PLAINTEXT"
+      # INTER_BROKER_SECURITY_PROTOCOL="PLAINTEXT"
+    {{ end }}
+    SASL_ENABLED_MECHANISMS=""
+    
+    if [[ "$KAFKA_CLIENT_ENABLED" = "true" ]]; then
+      LISTENERS="${LISTENERS},CLIENT://0.0.0.0:${KAFKA_CLIENT_PORT}"
+      ADVERTISED_LISTENERS="${ADVERTISED_LISTENERS},CLIENT://$(hostname -f):${KAFKA_CLIENT_PORT}"
+    
+      if [[ "$KAFKA_CLIENT_AUTHENTICATION" = "scram-sha-512" ]]; then
+        SASL_ENABLED_MECHANISMS="SCRAM-SHA-512\n$SASL_ENABLED_MECHANISMS"
+        LISTENER_SECURITY_PROTOCOL_MAP="${LISTENER_SECURITY_PROTOCOL_MAP},CLIENT:SASL_PLAINTEXT"
+        CLIENT_LISTENER=$(cat <<EOF
+    # CLIENT listener authentication
+    listener.name.client.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required;
+    EOF
+    )
+      else
+        LISTENER_SECURITY_PROTOCOL_MAP="${LISTENER_SECURITY_PROTOCOL_MAP},CLIENT:PLAINTEXT"
+      fi
+    fi
+    
+    export KAFKA_LOG_DIR_PATH="${LOG_DIR}/log${KAFKA_BROKER_ID}"
+    
+    if [[ -e ${KAFKA_HOME}/init/rack.id ]]; then
+      export RACK_ID=$(cat ${KAFKA_HOME}/init/rack.id)
+    fi
+
+    {{ if eq .Params.AUTHORIZATION_ENABLED "true" }}
+    # Calculate Kafka Authorization Super Users
+    SUPER_USERS=()
+    {{ if .Params.AUTHORIZATION_SUPER_USERS }}
+    SUPER_USERS="{{ .Params.AUTHORIZATION_SUPER_USERS }}"
+    SUPER_USERS=(${SUPER_USERS//;/ })
+    {{ end }}
+    {{ if eq .Params.KERBEROS_ENABLED "true" }}
+    SUPER_USERS=("${SUPER_USERS[@]}" "User:{{ .Params.KERBEROS_PRIMARY }}")
+    {{ end }}
+    SUPER_USERS=$(printf ";%s" "${SUPER_USERS[@]}")
+    SUPER_USERS=${SUPER_USERS:1}
+    {{ end }}
+
+    # Set Environment
+    echo "KAFKA_OPTS=\"$KAFKA_OPTS\"" > ${KAFKA_HOME}/.env
+    
+    KAFKA_CONFIGURATION=$(cat /config/server.properties)
+    # Write the config file
+    cat > ${KAFKA_HOME}/server.properties <<EOF
+    broker.id=${KAFKA_BROKER_ID}
+    broker.rack=${RACK_ID}
+    # Listeners
+    listeners=${LISTENERS}
+    advertised.listeners=${ADVERTISED_LISTENERS}
+    listener.security.protocol.map=${LISTENER_SECURITY_PROTOCOL_MAP}
+    inter.broker.listener.name=INTERNAL
+    #security.inter.broker.protocol=${INTER_BROKER_SECURITY_PROTOCOL}
+    {{ if eq .Params.AUTHORIZATION_ENABLED "true" }}
+    super.users=${SUPER_USERS}
+    {{ end }}
+    # Logs
+    log.dirs=${KAFKA_LOG_DIR_PATH}
+    # Provided configuration
+    ${KAFKA_CONFIGURATION}
+    EOF
+
+kind: ConfigMap
+metadata:
+  name: bootstrap

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bootstrap
 data:
   bootstrap.sh: |
     #!/usr/bin/env bash
@@ -27,11 +30,11 @@ data:
     # ADVERTISED LISTENERS
     ADVERTISED_LISTENERS="INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}"
     {{ if eq .Params.KERBEROS_ENABLED "true" }}
-      LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_PLAINTEXT"
-      # INTER_BROKER_SECURITY_PROTOCOL="SASL_PLAINTEXT"
+    LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_PLAINTEXT"
+    # INTER_BROKER_SECURITY_PROTOCOL="SASL_PLAINTEXT"
     {{ else }}
-      LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:PLAINTEXT"
-      # INTER_BROKER_SECURITY_PROTOCOL="PLAINTEXT"
+    LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:PLAINTEXT"
+    # INTER_BROKER_SECURITY_PROTOCOL="PLAINTEXT"
     {{ end }}
     SASL_ENABLED_MECHANISMS=""
     
@@ -94,7 +97,3 @@ data:
     # Provided configuration
     ${KAFKA_CONFIGURATION}
     EOF
-
-kind: ConfigMap
-metadata:
-  name: bootstrap

--- a/repository/kafka/operator/templates/health-check.yaml
+++ b/repository/kafka/operator/templates/health-check.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: health-check-script
 data:
   health-check.sh: |
     #!/usr/bin/env bash
@@ -27,7 +30,7 @@ data:
     if ! ${KAFKA_HOME}/bin/kafka-topics.sh --list --zookeeper $KAFKA_ZK_URI | grep -q ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX}
     then
       {{ if eq .Params.KERBEROS_ENABLED "true" }}
-        export KAFKA_OPTS="-Djava.security.auth.login.config=${KAFKA_HOME}/config/kafka_server_jaas.conf -Djava.security.krb5.conf=${KAFKA_HOME}/config/krb5.conf"
+      export KAFKA_OPTS="-Djava.security.auth.login.config=${KAFKA_HOME}/config/kafka_server_jaas.conf -Djava.security.krb5.conf=${KAFKA_HOME}/config/krb5.conf"
       {{ end }}
       
       ${KAFKA_HOME}/bin/kafka-topics.sh --create \
@@ -92,7 +95,3 @@ data:
       exit 1
     fi
     {{ end }}
-
-kind: ConfigMap
-metadata:
-  name: health-check-script

--- a/repository/kafka/operator/templates/health-check.yaml
+++ b/repository/kafka/operator/templates/health-check.yaml
@@ -6,15 +6,44 @@ data:
     set -e
     
     POD_INSTANCE_INDEX=${HOSTNAME##*-}
-    KAFKA_BROKER_ADDRESS=$HOSTNAME
+    KAFKA_BROKER_ADDRESS=$(hostname -f)
     KAFKA_BROKER_PORT=$KAFKA_BROKER_PORT
     KAFKA_HEALTH_CHECK_TOPIC_PREFIX={{ .Params.LIVENESS_TOPIC_PREFIX }}
 
+    {{ if eq .Params.KERBEROS_ENABLED "true" }}
+    
+    printf 'KafkaClient {\ncom.sun.security.auth.module.Krb5LoginModule required\nuseKeyTab=true\nstoreKey=true\nuseTicketCache=false\nkeyTab="kafka.keytab"\nprincipal="{{ .Params.LIVENESS_KERBEROS_PRIMARY }}/%s@{{ .Params.KERBEROS_REALM }}";\n};' $(hostname -f) > /tmp/kafka_health_check_client_jaas.conf
+    {{ if eq .Params.KERBEROS_ENABLED_FOR_ZOOKEEPER "true" }}
+    printf '\nClient {\ncom.sun.security.auth.module.Krb5LoginModule required\nuseKeyTab=true\nstoreKey=true\nuseTicketCache=false\nkeyTab="kafka.keytab"\nprincipal="{{ .Params.LIVENESS_KERBEROS_PRIMARY }}/%s@{{ .Params.KERBEROS_REALM }}";\n};' $(hostname -f) >> /tmp/kafka_health_check_client_jaas.conf
+    {{ end }}
+    
+    export KAFKA_OPTS="-Djava.security.auth.login.config=/tmp/kafka_health_check_client_jaas.conf -Djava.security.krb5.conf=${KAFKA_HOME}/config/krb5.conf"
+    SECURITY_PROTOCOL=SASL_PLAINTEXT
+    
+    KAFKA_PRODUCER_CONFIG_OPTIONS="--producer-property sasl.mechanism=GSSAPI --producer-property security.protocol=$SECURITY_PROTOCOL --producer-property sasl.kerberos.service.name={{ .Params.KERBEROS_PRIMARY }}"
+    KAFKA_CONSUMER_CONFIG_OPTIONS="--consumer-property sasl.mechanism=GSSAPI --consumer-property security.protocol=$SECURITY_PROTOCOL --consumer-property sasl.kerberos.service.name={{ .Params.KERBEROS_PRIMARY }}"
+    {{ end }}
+
     if ! ${KAFKA_HOME}/bin/kafka-topics.sh --list --zookeeper $KAFKA_ZK_URI | grep -q ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX}
     then
+      {{ if eq .Params.KERBEROS_ENABLED "true" }}
+        export KAFKA_OPTS="-Djava.security.auth.login.config=${KAFKA_HOME}/config/kafka_server_jaas.conf -Djava.security.krb5.conf=${KAFKA_HOME}/config/krb5.conf"
+      {{ end }}
+      
       ${KAFKA_HOME}/bin/kafka-topics.sh --create \
         --zookeeper $KAFKA_ZK_URI --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} \
         --replica-assignment $POD_INSTANCE_INDEX 2>&1
+      
+      {{ if eq .Params.KERBEROS_ENABLED "true" }}
+      ${KAFKA_HOME}/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=$KAFKA_ZK_URI \
+        --add --allow-principal User:{{ .Params.LIVENESS_KERBEROS_PRIMARY }} \
+        --producer --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX}
+      ${KAFKA_HOME}/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=$KAFKA_ZK_URI \
+        --add --allow-principal User:{{ .Params.LIVENESS_KERBEROS_PRIMARY }} \
+        --consumer --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} \
+        --group ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX}Group
+      export KAFKA_OPTS="-Djava.security.auth.login.config=/tmp/kafka_health_check_client_jaas.conf -Djava.security.krb5.conf=${KAFKA_HOME}/config/krb5.conf"
+      {{ end }}
     fi
     
     # Create a random message
@@ -22,14 +51,28 @@ data:
     echo $random_message > /tmp/kafka_health_check_msg
   
     # Publish the message to topic
-    if [ $( ${KAFKA_HOME}/bin/kafka-console-producer.sh \
+    if [ $( ${KAFKA_HOME}/bin/kafka-console-producer.sh $KAFKA_PRODUCER_CONFIG_OPTIONS \
       --broker-list ${KAFKA_BROKER_ADDRESS}:${KAFKA_BROKER_PORT} \
       --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} 2>&1 < /tmp/kafka_health_check_msg | grep -c ">>" ) -ne 1 ]
     then
       echo "Health check falied as the message cannot be published! topic: ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} msg: $random_message"
       exit 1
     fi
-  
+    
+    {{ if eq .Params.KERBEROS_ENABLED "true" }}
+    if ${KAFKA_HOME}/bin/kafka-console-consumer.sh $KAFKA_CONSUMER_CONFIG_OPTIONS \
+        --bootstrap-server ${KAFKA_BROKER_ADDRESS}:${KAFKA_BROKER_PORT} \
+        --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} \
+        --group ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX}Group \
+        --from-beginning --max-messages 1 2>&1 | grep -q "Processed a total of 1 messages"
+    then
+      echo "Health check passed! topic: ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX}"
+      exit 0
+    else
+      echo "Health check falied as consumer cannot read any messages! topic: ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX}"
+      exit 1
+    fi
+    {{ else }}
     # Get the number of messages in the topic
     message_count=$(${KAFKA_HOME}/bin/kafka-run-class.sh kafka.tools.GetOffsetShell \
       --broker-list $KAFKA_BROKER_ADDRESS:$KAFKA_BROKER_PORT \
@@ -48,6 +91,7 @@ data:
       echo "Health check falied due to message mismatch! topic: ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} msg: $random_message"
       exit 1
     fi
+    {{ end }}
 
 kind: ConfigMap
 metadata:

--- a/repository/kafka/operator/templates/jaas-config.yaml
+++ b/repository/kafka/operator/templates/jaas-config.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jaas-config
 data:
   kafka_server_jaas.conf: |
     {{ if eq .Params.KERBEROS_ENABLED "true" }}
@@ -23,7 +26,3 @@ data:
     };
     {{ end }}    
     {{ end }}
-
-kind: ConfigMap
-metadata:
-  name: jaas-config

--- a/repository/kafka/operator/templates/jaas-config.yaml
+++ b/repository/kafka/operator/templates/jaas-config.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  kafka_server_jaas.conf: |
+    {{ if eq .Params.KERBEROS_ENABLED "true" }}
+    KafkaServer {
+        com.sun.security.auth.module.Krb5LoginModule required
+        useKeyTab=true
+        storeKey=true
+        useTicketCache=false
+        keyTab="kafka.keytab"
+        principal="{{ .Params.KERBEROS_PRIMARY }}/<HOSTNAME>@{{ .Params.KERBEROS_REALM }}";
+    };
+    
+    {{ if eq .Params.KERBEROS_ENABLED_FOR_ZOOKEEPER "true" }}
+    // Zookeeper client authentication
+    Client {
+        com.sun.security.auth.module.Krb5LoginModule required
+        useKeyTab=true
+        storeKey=true
+        useTicketCache=false
+        keyTab="kafka.keytab"
+        principal="{{ .Params.KERBEROS_PRIMARY }}/<HOSTNAME>@{{ .Params.KERBEROS_REALM }}";
+    };
+    {{ end }}    
+    {{ end }}
+
+kind: ConfigMap
+metadata:
+  name: jaas-config

--- a/repository/kafka/operator/templates/krb5-config.yaml
+++ b/repository/kafka/operator/templates/krb5-config.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: krb5-config
 data:
   krb5.conf: |
     [libdefaults]
@@ -8,7 +11,3 @@ data:
     {{ .Params.KERBEROS_REALM }} = {
     kdc = {{ .Params.KERBEROS_KDC_HOSTNAME }}:{{ .Params.KERBEROS_KDC_PORT }}
     }
-
-kind: ConfigMap
-metadata:
-  name: krb5-config

--- a/repository/kafka/operator/templates/krb5-config.yaml
+++ b/repository/kafka/operator/templates/krb5-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  krb5.conf: |
+    [libdefaults]
+    default_realm = {{ .Params.KERBEROS_REALM }}
+
+    [realms]
+    {{ .Params.KERBEROS_REALM }} = {
+    kdc = {{ .Params.KERBEROS_KDC_HOSTNAME }}:{{ .Params.KERBEROS_KDC_PORT }}
+    }
+
+kind: ConfigMap
+metadata:
+  name: krb5-config

--- a/repository/kafka/operator/templates/metrics-config.yaml
+++ b/repository/kafka/operator/templates/metrics-config.yaml
@@ -1,4 +1,8 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2016-03-30T18:14:41Z
+  name: metrics-config
 data:
   metrics.properties: |
     rules:
@@ -331,9 +335,3 @@ data:
       name: kafka_server_zookeeper_expired_per_sec
       help: The ZooKeeper session has expired. When a session expires, we can have leader changes and even a new controller. Alert if value of such events across a Kafka cluster and if the overall number is high
       type: UNTYPED
-
-
-kind: ConfigMap
-metadata:
-  creationTimestamp: 2016-03-30T18:14:41Z
-  name: metrics-config

--- a/repository/kafka/operator/templates/server.properties.yaml
+++ b/repository/kafka/operator/templates/server.properties.yaml
@@ -1,4 +1,8 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2016-03-30T18:14:41Z
+  name: serverproperties
 data:
   server.properties: |
     # Licensed to the Apache Software Foundation (ASF) under one or more
@@ -255,8 +259,3 @@ data:
     zookeeper.sync.time.ms={{ .Params.ZOOKEEPER_SYNC_TIME_MS }}
 
     {{ .Params.CUSTOM_SERVER_PROPERTIES }}
-
-kind: ConfigMap
-metadata:
-  creationTimestamp: 2016-03-30T18:14:41Z
-  name: serverproperties

--- a/repository/kafka/operator/templates/server.properties.yaml
+++ b/repository/kafka/operator/templates/server.properties.yaml
@@ -32,8 +32,19 @@ data:
     # The maximum size of a request that the socket server will accept (protection against OOM)
     socket.request.max.bytes={{ .Params.SOCKET_REQUEST_MAX_BYTES }}
 
+    {{ if eq .Params.KERBEROS_ENABLED "true" }}
+    ############################# Kerberos Settings #############################
+    sasl.mechanism.inter.broker.protocol=GSSAPI
+    sasl.enabled.mechanisms=GSSAPI
+    sasl.kerberos.service.name={{ .Params.KERBEROS_PRIMARY }}
+    {{ end }}
+
+
     ############################# Authorization Settings #############################
-    # TODO support Security settings
+    {{ if eq .Params.AUTHORIZATION_ENABLED "true" }}
+    authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
+    allow.everyone.if.no.acl.found={{ .Params.AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND }}
+    {{ end }}
 
     ############################# Log Basics #############################
 

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: k8skafka
           imagePullPolicy: Always
-          image: shubhanilbag/kafka:0.2.1-2.3.0
+          image: mesosphere/kafka:0.2.1-2.3.0
           resources:
             requests:
               memory: {{ .Params.BROKER_MEM }}

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: k8skafka
           imagePullPolicy: Always
-          image: mesosphere/kafka:0.2.0-2.3.0
+          image: shubhanilbag/kafka:0.2.1-2.3.0
           resources:
             requests:
               memory: {{ .Params.BROKER_MEM }}
@@ -35,9 +35,13 @@ spec:
             - containerPort: {{ .Params.BROKER_PORT }}
               name: server
           command:
-            - sh
+            - bash
             - -c
-            - "cp /health-check-script/health-check.sh health-check.sh; chmod +x health-check.sh; exec $KAFKA_HOME/bin/start-kafka.sh"
+          args:
+            - bash -c /bootstrap/bootstrap.sh;
+              source ${KAFKA_HOME}/.env;
+              echo "Starting the kafka broker using broker.id ${HOSTNAME##*-}...";
+              KAFKA_OPTS="${KAFKA_OPTS} ${METRICS_OPTS}" exec ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/server.properties;
           env:
             - name: KAFKA_HEAP_OPTS
               value : "-Xmx512M -Xms512M"
@@ -70,6 +74,8 @@ spec:
             - name: datadir
               mountPath: /var/lib/kafka
           {{ end }}
+            - name: bootstrap
+              mountPath: /bootstrap
             - name: config
               mountPath: /config
             - name: health-check-script
@@ -78,12 +84,18 @@ spec:
             - name: metrics
               mountPath: /metrics
           {{ end }}
+          {{ if eq .Params.KERBEROS_ENABLED "true" }}
+            - name: jass-config
+              mountPath: /jass-config
+            - name: krb5-config
+              mountPath: /krb5-config
+            - name: kafka-keytab
+              mountPath: /kafka-keytab
+              readOnly: true
+          {{ end }}
           readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - "$KAFKA_HOME/readiness-check.sh"
+            tcpSocket:
+              port: {{ .Params.BROKER_PORT }}
             initialDelaySeconds: {{ .Params.READINESS_INITIAL_DELAY_SECONDS }}
             periodSeconds: {{ .Params.READINESS_PERIOD_SECONDS }}
             timeoutSeconds: {{ .Params.READINESS_TIMEOUT_SECONDS }}
@@ -108,6 +120,10 @@ spec:
         runAsUser: 1000
         fsGroup: 1000
       volumes:
+        - name: bootstrap
+          configMap:
+            name: {{ .Name }}-bootstrap
+            defaultMode: 0777
         - name: config
           configMap:
             name: {{ .Name }}-serverproperties
@@ -117,6 +133,17 @@ spec:
         - name: health-check-script
           configMap:
             name: {{ .Name }}-health-check-script
+        {{ if eq .Params.KERBEROS_ENABLED "true" }}
+        - name: jass-config
+          configMap:
+            name: {{ .Name }}-jaas-config
+        - name: krb5-config
+          configMap:
+            name: {{ .Name }}-krb5-config
+        - name: kafka-keytab
+          secret:
+            secretName: {{ .Params.KERBEROS_KEYTAB_SECRET }}
+        {{ end }}
   volumeClaimTemplates:
     {{ if eq .Params.PERSISTENT_STORAGE "true" }}
     - metadata:

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: k8skafka
           imagePullPolicy: Always
-          image: mesosphere/kafka:0.2.1-2.3.0
+          image: mesosphere/kafka:0.3.0-2.3.0
           resources:
             requests:
               memory: {{ .Params.BROKER_MEM }}
@@ -38,7 +38,7 @@ spec:
             - bash
             - -c
           args:
-            - bash -c /bootstrap/bootstrap.sh;
+            - /bootstrap/bootstrap.sh;
               source ${KAFKA_HOME}/.env;
               echo "Starting the kafka broker using broker.id ${HOSTNAME##*-}...";
               KAFKA_OPTS="${KAFKA_OPTS} ${METRICS_OPTS}" exec ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/server.properties;


### PR DESCRIPTION
This PR-
1. Migrates all scripts and configuration (except metrics configuration) from `mesosphere/kafka:0.2.1-2.3.0` image to the operator as ConfigMaps.
2. Adds support for KDC Kerberos. The operator now accepts the name of a k8s secret as  a parameter which should contain the keytabs (base64 encoded). The KDC server `host`, `port`, `realm` can be configured. The `primary` of Kafka and livenessProbe client can also be configured.
3. Adds support for enabling Kafka AuthZ and Super Users
4. Adds Kerberos and Kafka ACL support to the health check (livenessProbe)
5. Changes the readinessProbe from script based netcat port check to a k8s tcp probe.