### PR TITLE
remove duplicated appVersion in zookeeper

### DIFF
--- a/repository/zookeeper/operator/operator.yaml
+++ b/repository/zookeeper/operator/operator.yaml
@@ -3,7 +3,6 @@ version: "0.2.0"
 kudoVersion: 0.5.0
 appVersion: 3.4.14
 kubernetesVersion: 1.15.0
-appVersion: 3.4.10
 maintainers:
   - name: Alena Varkockova
     email: avarkockova@mesosphere.com


### PR DESCRIPTION
remove `appVersion` that was duplicated in zookeeper as a result of two PRs adding different versions