### PR TITLE
kafka: add support for TLS encryption

### DIFF
--- a/repository/kafka/docs/latest/security.md
+++ b/repository/kafka/docs/latest/security.md
@@ -1,8 +1,60 @@
 # Security
 
+The KUDO Kafka service supports Kafka’s native transport **encryption**, **authentication**, and **authorization** mechanisms. The service provides automation and orchestration to simplify the use of these important features. For more information on Kafka’s security, read the [security](http://kafka.apache.org/documentation/#security) section of official Apache Kafka documentation.
+
+## Encryption
+
+By default, KUDO Kafka brokers use the plaintext protocol for its inter-broker communication. It is recommended to enable the TLS encryption, to secure the communication between brokers. 
+
+### Enabling  TLS encryption
+
+Create the TLS certificate to be used for Kafka TLS encryptions
+
+```
+openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout tls.key -out tls.crt -subj "/CN=Kafka" -days 365
+```
+
+Create a kubernetes TLS secret using the certificate created in previous step 
+
+```
+kubectl create secret tls kafka-tls -n kudo-kafka --cert=tls.crt --key=tls.key
+```
+
+:warning: Make sure to create the certificate in the same namespace where the KUDO Kafka is being installed.
+
+```
+kubectl kudo install kafka \
+    --instance=kafka --namespace=kudo-kafka \
+    -p TRANSPORT_ENCRYPTION_ENABLED=true \
+    -p TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT=false \
+    -p SSL_AUTHENTICATION_ENABLED=false \
+    -p TLS_SECRET_NAME=kafka-tls
+```
+
 ## Authentication
 
-KUDO Kafka currently supports Kerberos authentication.
+KUDO Kafka supports two authentication mechanisms, TLS and Kerberos. The two are supported independently and may not be combined. If both TLS and Kerberos authentication are enabled, the service will use Kerberos authentication
+
+### TLS Authentication
+
+TLS authentication requires TLS encryption to be enabled. The configuration of TLS authentication is a superset of the required configurations that enables TLS encryption and also TLS authentication. Its not possible to enable only the TLS authentication without enabling the TLS encryption.
+
+Follow the steps of creating the TLS secret for the [TLS encryption](#enabling-tls-encryption) 
+
+And enable the TLS encryption and also set the parameter `SSL_AUTHENTICATION_ENABLED` to `true`
+
+```
+kubectl kudo install kafka \
+  --instance=kafka --namespace=kudo-kafka \
+    -p AUTHORIZATION_ENABLED=true \
+    -p AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND=false \
+    -p AUTHORIZATION_SUPER_USERS="User:livenessProbe;User:User1" \
+    -p TRANSPORT_ENCRYPTION_ENABLED=true \
+    -p TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT=false \
+    -p SSL_AUTHENTICATION_ENABLED=true
+```
+
+
 
 ### Kerberos Authentication
 
@@ -54,15 +106,15 @@ The KUDO Kafka service uses a keytab containing all node principals (service key
 
 ## Authorization
 
-The KUDO Kafka service supports Kafka’s ACL-based authorization system. To use Kafka’s ACLs, Kerberos authentication must be enabled as detailed above.
+The KUDO Kafka service supports Kafka’s ACL-based authorization system.  To use Kafka’s ACLs, either TLS or Kerberos authentication must be enabled as detailed above.
 
 ### Enable Authorization
 
 #### Prerequisites
 
-* Completion of Kerberos authentication above.
+* Completion of Kerberos authentication or TLS authentication as detailed above.
 
-### Install the Service
+### Example with Kerberos
 
 Install the KUDO Kafka service with the following options in addition to your own (remember, Kerberos must be enabled):
 
@@ -82,5 +134,29 @@ kubectl kudo install kafka \
 ```
 
 The format of the list is `User:user1;User:user2;....` Using Kerberos authentication, the “user” value is the Kerberos primary. The Kafka brokers themselves are automatically designated as super users.
+
+### Example with TLS
+
+Install the KUDO Kafka service with the following options in addition to your own (remember, TLS authentication must be enabled):
+
+```
+kubectl kudo install kafka \
+  --instance=kafka --namespace=kudo-kafka \
+    -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
+    -p BROKER_CPUS=200m \
+    -p BROKER_COUNT=3 \
+    -p BROKER_MEM=800m \
+    -p DISK_SIZE=10Gi \
+    -p KERBEROS_ENABLED=false \
+    -p KERBEROS_DEBUG=false \
+    -p AUTHORIZATION_ENABLED=true \
+    -p AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND=false \
+    -p AUTHORIZATION_SUPER_USERS="User:livenessProbe;User:User1" \
+    -p TRANSPORT_ENCRYPTION_ENABLED=true \
+    -p TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT=false \
+    -p SSL_AUTHENTICATION_ENABLED=true
+```
+
+
 
 NOTE: It is possible to enable Authorization after initial installation but the service may become unavailable during the transition. Additionally, Kafka clients may fail to function if they do not have the correct ACLs assigned to their principals. During the transition `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` can be set to `true` to prevent clients from failing until their ACLs can be set correctly. After the transition, `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` should be reset back to `false`.

--- a/repository/kafka/docs/latest/security.md
+++ b/repository/kafka/docs/latest/security.md
@@ -48,7 +48,7 @@ kubectl kudo install kafka \
   --instance=kafka --namespace=kudo-kafka \
     -p AUTHORIZATION_ENABLED=true \
     -p AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND=false \
-    -p AUTHORIZATION_SUPER_USERS="User:livenessProbe;User:User1" \
+    -p AUTHORIZATION_SUPER_USERS="User:User1" \
     -p TRANSPORT_ENCRYPTION_ENABLED=true \
     -p TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT=false \
     -p SSL_AUTHENTICATION_ENABLED=true
@@ -147,11 +147,9 @@ kubectl kudo install kafka \
     -p BROKER_COUNT=3 \
     -p BROKER_MEM=800m \
     -p DISK_SIZE=10Gi \
-    -p KERBEROS_ENABLED=false \
-    -p KERBEROS_DEBUG=false \
     -p AUTHORIZATION_ENABLED=true \
     -p AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND=false \
-    -p AUTHORIZATION_SUPER_USERS="User:livenessProbe;User:User1" \
+    -p AUTHORIZATION_SUPER_USERS="User:User1" \
     -p TRANSPORT_ENCRYPTION_ENABLED=true \
     -p TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT=false \
     -p SSL_AUTHENTICATION_ENABLED=true

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -18,6 +18,7 @@ tasks:
       - health-check.yaml
       - jaas-config.yaml
       - krb5-config.yaml
+      - enable-tls.yaml
       - statefulset.yaml
   update:
     resources:
@@ -29,6 +30,7 @@ tasks:
     - health-check.yaml
     - jaas-config.yaml
     - krb5-config.yaml
+    - enable-tls.yaml
     - statefulset.yaml
   not-allowed:
     resources:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -38,6 +38,10 @@ BROKER_PORT:
   description: "Port brokers run on"
   default: "9093"
 
+BROKER_PORT_TLS:
+  description: "Port tls enabled brokers run on"
+  default: "9095"
+
 DISK_SIZE:
   description: "Disk size for the brokers"
   default: "5Gi"
@@ -712,6 +716,18 @@ ZOOKEEPER_SYNC_TIME_MS:
   displayName: "zookeeper.sync.time.ms"
   description: "How far a ZK follower can be behind a ZK leader"
   default: "2000"
+
+TRANSPORT_ENCRYPTION_ENABLED:
+  default: "false"
+
+TRANSPORT_ENCRYPTION_CIPHERS:
+  default: "TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+
+TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT:
+  default: "false"
+
+SSL_AUTHENTICATION_ENABLED:
+  default: "false"
 
 CUSTOM_SERVER_PROPERTIES:
   displayName: "custom server properties"

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -39,7 +39,7 @@ BROKER_PORT:
   default: "9093"
 
 BROKER_PORT_TLS:
-  description: "Port tls enabled brokers run on"
+  description: "Port TLS-enabled brokers run on"
   default: "9095"
 
 DISK_SIZE:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -718,16 +718,29 @@ ZOOKEEPER_SYNC_TIME_MS:
   default: "2000"
 
 TRANSPORT_ENCRYPTION_ENABLED:
+  displayName: "Enable transport encryption (TLS)"
+  description: "Enable transport encryption (TLS)"
   default: "false"
 
 TRANSPORT_ENCRYPTION_CIPHERS:
+  displayName: "Cipher Suite Names"
+  description: "Comma-separated list of JSSE Cipher Suite Names"
   default: "TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
 
 TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT:
+  displayName: "Allow Plaintext Traffic"
+  description: "Allow plaintext alongside encrypted traffic"
   default: "false"
 
 SSL_AUTHENTICATION_ENABLED:
+  displayName: "Enable SSL authentication"
+  description: "Enable SSL authentication"
   default: "false"
+
+TLS_SECRET_NAME:
+  default: "kafka-tls"
+  displayName: "kafka-tls"
+  description: "The secret that contains TLS certificate and is mounted as a volume to make them available to the brokers."
 
 CUSTOM_SERVER_PROPERTIES:
   displayName: "custom server properties"

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -9,35 +9,62 @@ data:
     cp /health-check-script/health-check.sh health-check.sh;
     chmod +x health-check.sh;
 
+    {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+    /etc/tls/bin/enable-tls.sh
+    {{ end }}
+
     {{ if eq .Params.KERBEROS_ENABLED "true" }}
-    
     cat /kafka-keytab/kafka.keytab | base64 --decode > kafka.keytab;
     cp /jass-config/kafka_server_jaas.conf $KAFKA_HOME/config/kafka_server_jaas.conf;
     cp /krb5-config/krb5.conf $KAFKA_HOME/config/krb5.conf;
     sed -i "s/<HOSTNAME>/$(hostname -f)/g" $KAFKA_HOME/config/kafka_server_jaas.conf;
     export KAFKA_OPTS="-Djava.security.auth.login.config=${KAFKA_HOME}/config/kafka_server_jaas.conf -Djava.security.krb5.conf=${KAFKA_HOME}/config/krb5.conf $KAFKA_OPTS"
-    
     {{ if eq .Params.KERBEROS_DEBUG "true" }}
     export KAFKA_OPTS="-Dsun.security.krb5.debug=true $KAFKA_OPTS"
     {{ end }}
-    
     {{ end }}
     
     KAFKA_BROKER_ID=${HOSTNAME##*-}
     
-    # LISTENERS CONFIGURATION
-    LISTENERS="INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}"
-    # ADVERTISED LISTENERS
-    ADVERTISED_LISTENERS="INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}"
-    {{ if eq .Params.KERBEROS_ENABLED "true" }}
-    LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_PLAINTEXT"
-    # INTER_BROKER_SECURITY_PROTOCOL="SASL_PLAINTEXT"
-    {{ else }}
-    LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:PLAINTEXT"
-    # INTER_BROKER_SECURITY_PROTOCOL="PLAINTEXT"
+    LISTENERS=()
+    ADVERTISED_LISTENERS=()
+
+    # TODO: Fix indentation before final PR
+    {{ if eq .Params.KERBEROS_ENABLED "true" }} # Kerberos enabled
+        {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }} # Transport encryption on
+            LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT_TLS}")
+            ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT_TLS}")
+            {{ if eq .Params.TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT "true" }} # Allow plaintext as well
+                LISTENERS=("${LISTENERS[@]}" "EXTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
+                ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "EXTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
+            {{ end }}
+            LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_SSL,EXTERNAL:SASL_PLAINTEXT"
+        {{ else }} # Plaintext only
+            LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
+            ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
+            LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_PLAINTEXT"
+        {{ end }}
+    {{ else if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }} # No kerberos, but Transport encryption is on
+        LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT_TLS}")
+        ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT_TLS}")
+        {{ if eq .Params.TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT "true" }} # Plaintext allowed
+            LISTENERS=("${LISTENERS[@]}" "EXTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
+            ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "EXTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
+        {{ end }}
+        LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SSL,EXTERNAL:PLAINTEXT"
+    {{ else }} # No TLS, no Kerberos, Plaintext only
+        LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
+        ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
+        LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:PLAINTEXT"
+        # TODO: Ask ZM if need to support legacy behaviour in AL
     {{ end }}
-    SASL_ENABLED_MECHANISMS=""
-    
+
+    LISTENERS=$(printf ",%s" "${LISTENERS[@]}")
+    LISTENERS=${LISTENERS:1}
+    ADVERTISED_LISTENERS=$(printf ",%s" "${ADVERTISED_LISTENERS[@]}")
+    ADVERTISED_LISTENERS=${ADVERTISED_LISTENERS:1}
+
+    SASL_ENABLED_MECHANISMS=""    
     if [[ "$KAFKA_CLIENT_ENABLED" = "true" ]]; then
       LISTENERS="${LISTENERS},CLIENT://0.0.0.0:${KAFKA_CLIENT_PORT}"
       ADVERTISED_LISTENERS="${ADVERTISED_LISTENERS},CLIENT://$(hostname -f):${KAFKA_CLIENT_PORT}"
@@ -88,7 +115,6 @@ data:
     advertised.listeners=${ADVERTISED_LISTENERS}
     listener.security.protocol.map=${LISTENER_SECURITY_PROTOCOL_MAP}
     inter.broker.listener.name=INTERNAL
-    #security.inter.broker.protocol=${INTER_BROKER_SECURITY_PROTOCOL}
     {{ if eq .Params.AUTHORIZATION_ENABLED "true" }}
     super.users=${SUPER_USERS}
     {{ end }}

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -97,6 +97,14 @@ data:
     {{ end }}
     {{ if eq .Params.KERBEROS_ENABLED "true" }}
     SUPER_USERS=("${SUPER_USERS[@]}" "User:{{ .Params.KERBEROS_PRIMARY }}")
+    {{ else if eq .Params.SSL_AUTHENTICATION_ENABLED "true" }}
+    #TODO: Minify!
+    POD_INSTANCE_INDEX=${HOSTNAME##*-}
+    for i in $(seq 0 2)
+    do
+      dns=$(hostname -f | sed s/$POD_INSTANCE_INDEX/$i/)
+      SUPER_USERS=("${SUPER_USERS[@]}" "User:$dns")
+    done
     {{ end }}
     SUPER_USERS=$(printf ";%s" "${SUPER_USERS[@]}")
     SUPER_USERS=${SUPER_USERS:1}

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -29,34 +29,41 @@ data:
     LISTENERS=()
     ADVERTISED_LISTENERS=()
 
-    # TODO: Fix indentation before final PR
-    {{ if eq .Params.KERBEROS_ENABLED "true" }} # Kerberos enabled
-        {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }} # Transport encryption on
-            LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT_TLS}")
-            ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT_TLS}")
-            {{ if eq .Params.TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT "true" }} # Allow plaintext as well
-                LISTENERS=("${LISTENERS[@]}" "EXTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
-                ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "EXTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
-            {{ end }}
-            LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_SSL,EXTERNAL:SASL_PLAINTEXT"
-        {{ else }} # Plaintext only
-            LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
-            ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
-            LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_PLAINTEXT"
-        {{ end }}
-    {{ else if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }} # No kerberos, but Transport encryption is on
-        LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT_TLS}")
-        ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT_TLS}")
-        {{ if eq .Params.TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT "true" }} # Plaintext allowed
-            LISTENERS=("${LISTENERS[@]}" "EXTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
-            ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "EXTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
-        {{ end }}
-        LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SSL,EXTERNAL:PLAINTEXT"
-    {{ else }} # No TLS, no Kerberos, Plaintext only
-        LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
-        ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
-        LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:PLAINTEXT"
-        # TODO: Ask ZM if need to support legacy behaviour in AL
+    {{ if eq .Params.KERBEROS_ENABLED "true" }}
+    # Kerberos enabled
+    {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+    # Transport encryption on
+    LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT_TLS}")
+    ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT_TLS}")
+    {{ if eq .Params.TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT "true" }}
+    # Allow plaintext as well
+    LISTENERS=("${LISTENERS[@]}" "EXTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
+    ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "EXTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
+    {{ end }}
+    LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_SSL,EXTERNAL:SASL_PLAINTEXT"
+    {{ else }}
+    # Plaintext only
+    LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
+    ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
+    LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SASL_PLAINTEXT"
+    {{ end }}
+    #
+    {{ else if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+    # No kerberos, but Transport encryption is on
+    LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT_TLS}")
+    ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT_TLS}")
+    {{ if eq .Params.TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT "true" }}
+    # Plaintext allowed
+    LISTENERS=("${LISTENERS[@]}" "EXTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
+    ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "EXTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
+    {{ end }}
+    LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:SSL,EXTERNAL:PLAINTEXT"
+    #
+    {{ else }}
+    # No TLS, no Kerberos, Plaintext only
+    LISTENERS=("${LISTENERS[@]}" "INTERNAL://0.0.0.0:${KAFKA_BROKER_PORT}")
+    ADVERTISED_LISTENERS=("${ADVERTISED_LISTENERS[@]}" "INTERNAL://$(hostname -f):${KAFKA_BROKER_PORT}")
+    LISTENER_SECURITY_PROTOCOL_MAP="INTERNAL:PLAINTEXT"
     {{ end }}
 
     LISTENERS=$(printf ",%s" "${LISTENERS[@]}")
@@ -98,12 +105,9 @@ data:
     {{ if eq .Params.KERBEROS_ENABLED "true" }}
     SUPER_USERS=("${SUPER_USERS[@]}" "User:{{ .Params.KERBEROS_PRIMARY }}")
     {{ else if eq .Params.SSL_AUTHENTICATION_ENABLED "true" }}
-    #TODO: Minify!
-    POD_INSTANCE_INDEX=${HOSTNAME##*-}
-    for i in $(seq 0 2)
+    for i in $(seq 0 $(( {{ .Params.BROKER_COUNT }} - 1 )))
     do
-      dns=$(hostname -f | sed s/$POD_INSTANCE_INDEX/$i/)
-      SUPER_USERS=("${SUPER_USERS[@]}" "User:$dns")
+      SUPER_USERS=("${SUPER_USERS[@]}" "User:$(hostname -f | sed s/$KAFKA_BROKER_ID/$i/)")
     done
     {{ end }}
     SUPER_USERS=$(printf ";%s" "${SUPER_USERS[@]}")

--- a/repository/kafka/operator/templates/enable-tls.yaml
+++ b/repository/kafka/operator/templates/enable-tls.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: enable-tls
+data:
+  enable-tls.sh: |
+    #!/usr/bin/env bash
+    set -e
+    pushd /home/kafka
+    mkdir -p tls
+    pushd tls
+    # COPY CA AUTHORITY CERTIFICATE AND KEY OBTAINED FROM SECRETS
+    cp /etc/tls/certs/tls.crt /home/kafka/tls/tls.crt
+    cp /etc/tls/certs/tls.key /home/kafka/tls/tls.key
+    # GENERATE KEYSTORE AND TRUSTSTORE
+    keytool -keystore kafka.server.keystore.jks \
+            -alias localhost \
+            -validity 900 \
+            -genkey \
+            -keyalg RSA \
+            -dname "CN=kafka" \
+            -storepass changeit \
+            -keypass changeit \
+            -noprompt
+    # Add the CACert to the client and server truststores so that clients and server can trust this CA
+    keytool -keystore kafka.client.truststore.jks \
+            -alias CARoot \
+            -import \
+            -file /home/kafka/tls/tls.crt \
+            -storepass changeit \
+            -noprompt
+    keytool -keystore kafka.server.truststore.jks \
+            -alias CARoot \
+            -importcert \
+            -file /home/kafka/tls/tls.crt \
+            -storepass changeit \
+            -noprompt
+    # Create a certificate signing request
+    keytool -keystore kafka.server.keystore.jks \
+            -alias localhost \
+            -certreq \
+            -file cert-req \
+            -storepass changeit
+    # Add openssl certificate signing extension config file
+    cat > csr.conf <<EOF
+    [ req_ext ]
+    subjectAltName = @alt_names
+    extendedKeyUsage = serverAuth, clientAuth
+    
+    [ alt_names ]
+    DNS.1 = localhost
+    DNS.2 = 127.0.0.1
+    DNS.3 = $(hostname -f)
+    DNS.4 = $(hostname -i)
+    DNS.5 = $(hostname)
+    IP.1 = 0.0.0.0
+    IP.2 = 127.0.0.1
+    IP.3 = $(hostname -i)
+    EOF
+    # Sign the certificate with the CA & CAKey
+    openssl x509 -req \
+        -CA /home/kafka/tls/tls.crt \
+        -CAkey /home/kafka/tls/tls.key \
+        -in cert-req \
+        -out cert-signed \
+        -days 900 \
+        -CAcreateserial \
+        -passin pass:changeit \
+        -extfile csr.conf \
+        -extensions req_ext
+    # Import the CA cert into server keystore
+    keytool -keystore kafka.server.keystore.jks \
+            -alias CARoot \
+            -import \
+            -file /home/kafka/tls/tls.crt \
+            -storepass changeit -noprompt
+    # Import the signed certificate into server keystore
+    keytool -keystore kafka.server.keystore.jks \
+            -alias localhost \
+            -import \
+            -file cert-signed \
+            -storepass changeit -noprompt
+    popd
+    popd

--- a/repository/kafka/operator/templates/enable-tls.yaml
+++ b/repository/kafka/operator/templates/enable-tls.yaml
@@ -18,7 +18,7 @@ data:
             -validity 900 \
             -genkey \
             -keyalg RSA \
-            -dname "CN=kafka" \
+            -dname "CN=$(hostname -f)" \
             -storepass changeit \
             -keypass changeit \
             -noprompt

--- a/repository/kafka/operator/templates/enable-tls.yaml
+++ b/repository/kafka/operator/templates/enable-tls.yaml
@@ -6,7 +6,7 @@ data:
   enable-tls.sh: |
     #!/usr/bin/env bash
     set -e
-    mkdir -p home/kafka/tls
+    mkdir -p /home/kafka/tls
     pushd /home/kafka/tls
     # COPY CA AUTHORITY CERTIFICATE AND KEY OBTAINED FROM SECRETS
     cp /etc/tls/certs/tls.crt /home/kafka/tls/tls.crt

--- a/repository/kafka/operator/templates/enable-tls.yaml
+++ b/repository/kafka/operator/templates/enable-tls.yaml
@@ -6,9 +6,8 @@ data:
   enable-tls.sh: |
     #!/usr/bin/env bash
     set -e
-    pushd /home/kafka
-    mkdir -p tls
-    pushd tls
+    mkdir -p home/kafka/tls
+    pushd /home/kafka/tls
     # COPY CA AUTHORITY CERTIFICATE AND KEY OBTAINED FROM SECRETS
     cp /etc/tls/certs/tls.crt /home/kafka/tls/tls.crt
     cp /etc/tls/certs/tls.key /home/kafka/tls/tls.key
@@ -80,5 +79,4 @@ data:
             -import \
             -file cert-signed \
             -storepass changeit -noprompt
-    popd
     popd

--- a/repository/kafka/operator/templates/health-check.yaml
+++ b/repository/kafka/operator/templates/health-check.yaml
@@ -13,6 +13,12 @@ data:
     KAFKA_BROKER_PORT=$KAFKA_BROKER_PORT
     KAFKA_HEALTH_CHECK_TOPIC_PREFIX={{ .Params.LIVENESS_TOPIC_PREFIX }}
 
+    {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+    KAFKA_BROKER_PORT=$KAFKA_BROKER_PORT_TLS
+    KAFKA_PRODUCER_CONFIG_OPTIONS="--producer-property security.protocol=SSL --producer-property ssl.keystore.location=/home/kafka/tls/kafka.server.keystore.jks --producer-property ssl.keystore.password=changeit --producer-property ssl.key.password=changeit --producer-property ssl.truststore.location=/home/kafka/tls/kafka.server.truststore.jks --producer-property ssl.truststore.password=changeit"
+    KAFKA_CONSUMER_CONFIG_OPTIONS="--consumer-property security.protocol=SSL --consumer-property ssl.keystore.location=/home/kafka/tls/kafka.server.keystore.jks --consumer-property ssl.keystore.password=changeit --consumer-property ssl.key.password=changeit --consumer-property ssl.truststore.location=/home/kafka/tls/kafka.server.truststore.jks --consumer-property ssl.truststore.password=changeit"
+    {{ end }}
+
     {{ if eq .Params.KERBEROS_ENABLED "true" }}
     
     printf 'KafkaClient {\ncom.sun.security.auth.module.Krb5LoginModule required\nuseKeyTab=true\nstoreKey=true\nuseTicketCache=false\nkeyTab="kafka.keytab"\nprincipal="{{ .Params.LIVENESS_KERBEROS_PRIMARY }}/%s@{{ .Params.KERBEROS_REALM }}";\n};' $(hostname -f) > /tmp/kafka_health_check_client_jaas.conf
@@ -21,10 +27,14 @@ data:
     {{ end }}
     
     export KAFKA_OPTS="-Djava.security.auth.login.config=/tmp/kafka_health_check_client_jaas.conf -Djava.security.krb5.conf=${KAFKA_HOME}/config/krb5.conf"
+    {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+    SECURITY_PROTOCOL=SASL_SSL
+    {{ else }}
     SECURITY_PROTOCOL=SASL_PLAINTEXT
+    {{ end }}
     
-    KAFKA_PRODUCER_CONFIG_OPTIONS="--producer-property sasl.mechanism=GSSAPI --producer-property security.protocol=$SECURITY_PROTOCOL --producer-property sasl.kerberos.service.name={{ .Params.KERBEROS_PRIMARY }}"
-    KAFKA_CONSUMER_CONFIG_OPTIONS="--consumer-property sasl.mechanism=GSSAPI --consumer-property security.protocol=$SECURITY_PROTOCOL --consumer-property sasl.kerberos.service.name={{ .Params.KERBEROS_PRIMARY }}"
+    KAFKA_PRODUCER_CONFIG_OPTIONS="$KAFKA_PRODUCER_CONFIG_OPTIONS --producer-property sasl.mechanism=GSSAPI --producer-property security.protocol=$SECURITY_PROTOCOL --producer-property sasl.kerberos.service.name={{ .Params.KERBEROS_PRIMARY }}"
+    KAFKA_CONSUMER_CONFIG_OPTIONS="$KAFKA_CONSUMER_CONFIG_OPTIONS --consumer-property sasl.mechanism=GSSAPI --consumer-property security.protocol=$SECURITY_PROTOCOL --consumer-property sasl.kerberos.service.name={{ .Params.KERBEROS_PRIMARY }}"
     {{ end }}
 
     if ! ${KAFKA_HOME}/bin/kafka-topics.sh --list --zookeeper $KAFKA_ZK_URI | grep -q ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX}
@@ -62,7 +72,7 @@ data:
       exit 1
     fi
     
-    {{ if eq .Params.KERBEROS_ENABLED "true" }}
+    {{ if or (eq .Params.KERBEROS_ENABLED "true") (eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true") }}
     if ${KAFKA_HOME}/bin/kafka-console-consumer.sh $KAFKA_CONSUMER_CONFIG_OPTIONS \
         --bootstrap-server ${KAFKA_BROKER_ADDRESS}:${KAFKA_BROKER_PORT} \
         --topic ${KAFKA_HEALTH_CHECK_TOPIC_PREFIX}${POD_INSTANCE_INDEX} \

--- a/repository/kafka/operator/templates/server.properties.yaml
+++ b/repository/kafka/operator/templates/server.properties.yaml
@@ -36,13 +36,35 @@ data:
     # The maximum size of a request that the socket server will accept (protection against OOM)
     socket.request.max.bytes={{ .Params.SOCKET_REQUEST_MAX_BYTES }}
 
+    {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+    ############################# TLS Settings #############################
+    ssl.keystore.location=/home/kafka/tls/kafka.server.keystore.jks
+    ssl.keystore.password=changeit
+    ssl.key.password=changeit
+
+    ssl.truststore.location=/home/kafka/tls/kafka.server.truststore.jks
+    ssl.truststore.password=changeit
+    
+    ssl.enabled.protocols=TLSv1.2
+    
+    {{ if .Params.TRANSPORT_ENCRYPTION_CIPHERS }}
+    ssl.cipher.suites={{ .Params.TRANSPORT_ENCRYPTION_CIPHERS }}
+    {{ end }}
+    
+    # If Kerberos is NOT enabled, then SSL authentication can be turned on.
+    {{ if ne .Params.KERBEROS_ENABLED "true" }}
+    {{ if eq .Params.SSL_AUTHENTICATION_ENABLED "true" }}
+    ssl.client.auth=required
+    {{ end }}
+    {{ end }}
+    {{ end }}
+
     {{ if eq .Params.KERBEROS_ENABLED "true" }}
     ############################# Kerberos Settings #############################
     sasl.mechanism.inter.broker.protocol=GSSAPI
     sasl.enabled.mechanisms=GSSAPI
     sasl.kerberos.service.name={{ .Params.KERBEROS_PRIMARY }}
     {{ end }}
-
 
     ############################# Authorization Settings #############################
     {{ if eq .Params.AUTHORIZATION_ENABLED "true" }}

--- a/repository/kafka/operator/templates/server.properties.yaml
+++ b/repository/kafka/operator/templates/server.properties.yaml
@@ -70,6 +70,11 @@ data:
     {{ if eq .Params.AUTHORIZATION_ENABLED "true" }}
     authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
     allow.everyone.if.no.acl.found={{ .Params.AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND }}
+    {{ if ne .Params.KERBEROS_ENABLED "true" }}
+    {{ if eq .Params.SSL_AUTHENTICATION_ENABLED "true" }}
+    principal.builder.class=de.thmshmm.kafka.CustomPrincipalBuilder
+    {{ end }}
+    {{ end }}
     {{ end }}
 
     ############################# Log Basics #############################

--- a/repository/kafka/operator/templates/server.properties.yaml
+++ b/repository/kafka/operator/templates/server.properties.yaml
@@ -47,9 +47,7 @@ data:
     
     ssl.enabled.protocols=TLSv1.2
     
-    {{ if .Params.TRANSPORT_ENCRYPTION_CIPHERS }}
     ssl.cipher.suites={{ .Params.TRANSPORT_ENCRYPTION_CIPHERS }}
-    {{ end }}
     
     # If Kerberos is NOT enabled, then SSL authentication can be turned on.
     {{ if ne .Params.KERBEROS_ENABLED "true" }}

--- a/repository/kafka/operator/templates/service.yaml
+++ b/repository/kafka/operator/templates/service.yaml
@@ -10,6 +10,10 @@ spec:
   ports:
     - port: {{ .Params.BROKER_PORT }}
       name: server
+    {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+    - port: {{ .Params.BROKER_PORT_TLS }}
+      name: server-tls
+    {{ end }}
     - port: {{ .Params.CLIENT_PORT }}
       name: client
     {{ if eq .Params.METRICS_ENABLED "true" }}

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: k8skafka
           imagePullPolicy: Always
-          image: mesosphere/kafka:0.3.0-2.3.0
+          image: shubhanilbag/kafka:0.2.1-2.3.0
           resources:
             requests:
               memory: {{ .Params.BROKER_MEM }}

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -67,6 +67,8 @@ spec:
               value: "{{ .Params.CLIENT_PORT_ENABLED }}"
             - name: KAFKA_BROKER_PORT
               value: "{{ .Params.BROKER_PORT }}"
+            - name: KAFKA_BROKER_PORT_TLS
+              value: "{{ .Params.BROKER_PORT_TLS }}"
             - name: KAFKA_CLIENT_PORT
               value: "{{ .Params.CLIENT_PORT }}"
           volumeMounts:
@@ -93,9 +95,19 @@ spec:
               mountPath: /kafka-keytab
               readOnly: true
           {{ end }}
+          {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+            - name: kafka-tls
+              mountPath: /etc/tls/certs
+            - name: enable-tls
+              mountPath: /etc/tls/bin
+          {{ end }}
           readinessProbe:
             tcpSocket:
+              {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+              port: {{ .Params.BROKER_PORT_TLS }}
+              {{ else }}
               port: {{ .Params.BROKER_PORT }}
+              {{ end }}
             initialDelaySeconds: {{ .Params.READINESS_INITIAL_DELAY_SECONDS }}
             periodSeconds: {{ .Params.READINESS_PERIOD_SECONDS }}
             timeoutSeconds: {{ .Params.READINESS_TIMEOUT_SECONDS }}
@@ -110,7 +122,11 @@ spec:
               - "$KAFKA_HOME/health-check.sh"
             {{ else }}
             tcpSocket:
+              {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+              port: {{ .Params.BROKER_PORT_TLS }}
+              {{ else }}
               port: {{ .Params.BROKER_PORT }}
+              {{ end }}
             {{ end }}
             initialDelaySeconds: {{ .Params.LIVENESS_INITIAL_DELAY_SECONDS }}
             periodSeconds: {{ .Params.LIVENESS_PERIOD_SECONDS }}
@@ -143,6 +159,15 @@ spec:
         - name: kafka-keytab
           secret:
             secretName: {{ .Params.KERBEROS_KEYTAB_SECRET }}
+        {{ end }}
+        {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+        - name: kafka-tls
+          secret:
+            secretName: kafka-tls
+        - name: enable-tls
+          configMap:
+            name:  {{ .Name }}-enable-tls
+            defaultMode: 0777
         {{ end }}
   volumeClaimTemplates:
     {{ if eq .Params.PERSISTENT_STORAGE "true" }}

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -39,6 +39,7 @@ spec:
             - -c
           args:
             - /bootstrap/bootstrap.sh;
+              curl https://downloads.mesosphere.com/kafka/assets/kafka-custom-principal-builder-1.0.0.jar --output ${KAFKA_HOME}/libs/kafka-custom-principal-builder-1.0.0.jar;
               source ${KAFKA_HOME}/.env;
               echo "Starting the kafka broker using broker.id ${HOSTNAME##*-}...";
               KAFKA_OPTS="${KAFKA_OPTS} ${METRICS_OPTS}" exec ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/server.properties;

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -34,6 +34,10 @@ spec:
           ports:
             - containerPort: {{ .Params.BROKER_PORT }}
               name: server
+            {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+            - containerPort: {{ .Params.BROKER_PORT_TLS }}
+              name: server-tls
+            {{ end }}
           command:
             - bash
             - -c

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -164,7 +164,7 @@ spec:
         {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
         - name: kafka-tls
           secret:
-            secretName: kafka-tls
+            secretName: {{ .Params.TLS_SECRET_NAME }}
         - name: enable-tls
           configMap:
             name:  {{ .Name }}-enable-tls

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: k8skafka
           imagePullPolicy: Always
-          image: shubhanilbag/kafka:0.2.1-2.3.0
+          image: mesosphere/kafka:0.3.1-2.3.0
           resources:
             requests:
               memory: {{ .Params.BROKER_MEM }}
@@ -39,7 +39,6 @@ spec:
             - -c
           args:
             - /bootstrap/bootstrap.sh;
-              curl https://downloads.mesosphere.com/kafka/assets/kafka-custom-principal-builder-1.0.0.jar --output ${KAFKA_HOME}/libs/kafka-custom-principal-builder-1.0.0.jar;
               source ${KAFKA_HOME}/.env;
               echo "Starting the kafka broker using broker.id ${HOSTNAME##*-}...";
               KAFKA_OPTS="${KAFKA_OPTS} ${METRICS_OPTS}" exec ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/server.properties;


### PR DESCRIPTION
This PR-

1. Adds support to enable and configure kafka tls encryption (`SSL`).
2. Adds custom principal builder to use client certificate CNs as kafka super users when authorization is enabled
3. Adds support to use kerberos authentication along with tls encryption (`SASL_SSL`)
4. Adds TLS support to health check (livenessProbe)
5. Allows user defined TLS certificate to be added as a k8s secret (`-p TLS_SECRET_NAME`) which is used as CA certs for signing individual broker certificates
6. Uses `mesosphere/kafka:0.3.1-2.3.0` image
7. Adds documentation for configuring TLS with KUDO Kafka 