### PR TITLE
ci: disable docker_layer_caching for circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
   test:
     machine:
       enabled: true
-      # enabled to make kind cluster start faster.
-      docker_layer_caching: true
     parameters:
       kubernetes_version:
         type: string


### PR DESCRIPTION
we have CI failing for this repo

examples:
https://circleci.com/gh/kudobuilder/operators/754?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link


as pointed out by @alenkacz the reason might be https://discuss.circleci.com/t/blocked-due-to-free-plan-docker-layer-caching-unavailable-but-i-dont-build-docker-images/32844 

so removing the `docker_layer_caching` from configuration to see if this fixes the CI 