### PR TITLE
kafka: add custom configurations feature

### DIFF
--- a/repository/kafka/docs/latest/custom.md
+++ b/repository/kafka/docs/latest/custom.md
@@ -2,9 +2,11 @@
 
 KUDO Kafka is aiming to provide out of the box optimized Kafka clusters on Kubernetes, which can be tuned and configured using the parameters. 
 
-Advanced custom configuration is to empower the advanced users of the Kafka, so they aren't restricted by the parameters we expose in the KUDO Kafka configuration. 
+Custom configurations empower the advanced Kafka user so they aren't restricted by the parameters currently exposed in the KUDO Kafka configuration. 
 
-KUDO Kafka allows configuring the custom broker configuration using **CUSTOM_SERVER_PROPERTIES_CM_NAME** and custom metrics reporter configuration using **CUSTOM_METRICS_CM_NAME**
+KUDO Kafka allows configuring the following:
+- custom broker configurations using **CUSTOM_SERVER_PROPERTIES_CM_NAME** 
+- custom metrics-reporter configurations using **CUSTOM_METRICS_CM_NAME**
 
 ## Custom broker configuration
 
@@ -76,7 +78,7 @@ Starting the kafka broker using broker.id 0...
 ```
 #### Updating the custom configuration
 
-The KUDO Kafka custom configuration ConfigMap isn't watched by the KUDO controller. Therefore any updates done in the custom configuration will need a later rolling restart.
+The KUDO Kafka custom configuration ConfigMap isn't watched by the KUDO controller. Therefore any updates to the custom configurations will need a rolling restart of the statefulset.
 
 Edit the configmap with changes we want to rollout:
 
@@ -119,7 +121,7 @@ data:
         partition: "$5"
 ```
 
-To have the KUDO Kafka detect correctly the custom metrics reporter configuration `data` should have `metrics.properties` 
+To have KUDO Kafka detect correctly the custom metrics reporter configuration `data` should have `metrics.properties` 
 
 Create the ConfigMap in the namespace we will have the KUDO Kafka cluster
 
@@ -181,7 +183,7 @@ rules:
 
 #### Updating the custom metrics reporter 
 
-Like the custom configuration the custom metrics reporter is also not watched by the KUDO controller. Therefore to any updates done in the custom configuration will need a later rolling restart.
+Like the custom configuration the custom metrics reporter is also not watched by the KUDO controller. Therefore, any updates to the custom configurations will need a rolling restart to the statefulset.
 
 Edit the configmap with changes we want to rollout:
 

--- a/repository/kafka/docs/latest/custom.md
+++ b/repository/kafka/docs/latest/custom.md
@@ -1,0 +1,198 @@
+# Advanced Custom Configuration
+
+KUDO Kafka is aiming to provide out of the box optimized Kafka clusters on Kubernetes, which can be tuned and configured using the parameters. 
+
+Advanced custom configuration is to empower the advanced users of the Kafka, so they aren't restricted by the parameters we expose in the KUDO Kafka configuration. 
+
+KUDO Kafka allows configuring the custom broker configuration using **CUSTOM_SERVER_PROPERTIES_CM_NAME** and custom metrics reporter configuration using **CUSTOM_METRICS_CM_NAME**
+
+## Custom broker configuration
+
+To use the custom broker configuration, we need to create a configmap with the properties we want to override.
+
+Example custom configuration:
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-configuration
+data:
+  server.properties: |
+    ssl.secure.random.implementation=SHA1PRNG
+    connection.failed.authentication.delay.ms=300
+```
+
+Create the ConfigMap in the namespace we will have the KUDO Kafka cluster
+
+```
+> kubectl create -f custom-configuration.yaml -n kudo-kafka
+configmap/custom-configuration created
+```
+
+Verify the ConfigMap is created correctly 
+
+```
+> kubectl get configmap custom-configuration -n kudo-kafka -o yaml
+apiVersion: v1
+data:
+  server.properties: |
+    ssl.secure.random.implementation=SHA1PRNG
+    connection.failed.authentication.delay.ms=300
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2019-10-19T12:41:19Z"
+  name: custom-configuration
+  namespace: kudo-kafka
+  resourceVersion: "349819"
+  selfLink: /api/v1/namespaces/kudo-kafka/configmaps/custom-configuration
+  uid: 8a9f1520-ed3d-4b90-b544-a3e20d20fa5f
+```
+
+Now we are ready to start the KUDO Kafka cluster with custom configuration to be used with default tuned configuration. 
+
+```
+kubectl kudo install kafka \
+    --instance=kafka --namespace=kudo-kafka \
+    -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
+    -p BROKER_COUNT=3 \
+    -p CUSTOM_SERVER_PROPERTIES_CM_NAME=custom-configuration 
+```
+
+Verify in the logs if the custom configuration is being used in the Apache Kafka brokers and the `KafkaConfig` is correctly using `connection.failed.authentication.delay.ms` with value of `300` 
+
+```
+> kubectl logs kafka-kafka-0 -n kudo-kafka
+[2019-10-21 13:46:58,325] Appending custom configuration file to the server.properties...
+ssl.secure.random.implementation=SHA1PRNG
+connection.failed.authentication.delay.ms=300
+Starting the kafka broker using broker.id 0...
+[ ... lines removed for clarity ...]
+	compression.type = producer
+	connection.failed.authentication.delay.ms = 300
+	connections.max.idle.ms = 600000
+	connections.max.reauth.ms = 0
+[ ... lines removed for clarity ...]
+```
+#### Updating the custom configuration
+
+The KUDO Kafka custom configuration ConfigMap isn't watched by the KUDO controller. Therefore any updates done in the custom configuration will need a later rolling restart.
+
+Edit the configmap with changes we want to rollout:
+
+```
+> kubectl edit configmap custom-configuration -n kudo-kafka
+configmap/custom-configuration edited
+```
+
+Perform a rolling restart on the statefulset to reload the configmap.
+
+```
+> kubectl rollout restart statefulset kafka-kafka -n kudo-kafka
+statefulset.apps/kafka-kafka restarted
+```
+
+#### :warning: Excludelist of the custom configuration
+
+Users can update all the broker configuration properties except the `broker.id`, `listeners`,`advertised.listeners`,  `advertised.host.name`,  `listener.security.protocol.map` `log.dirs`
+## Custom metrics reporter 
+
+To use the custom metrics reporter configuration we need to create a configmap with the `metrics.yaml` we want to override.
+
+Example of metrics configuration:
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-config
+data:
+  metrics.properties: |
+    rules:
+    # Special cases and very specific rules
+    - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+      name: kafka_server_$1_$2
+      type: GAUGE
+      labels:
+        clientId: "$3"
+        topic: "$4"
+        partition: "$5"
+```
+
+To have the KUDO Kafka detect correctly the custom metrics reporter configuration `data` should have `metrics.properties` 
+
+Create the ConfigMap in the namespace we will have the KUDO Kafka cluster
+
+```
+> kubectl create -f metrics-configuration.yaml -n kudo-kafka
+configmap/metrics-config created
+```
+
+Verify the ConfigMap is created correctly 
+
+```
+> kubectl get configmap metrics-config -n kudo-kafka -o yaml
+apiVersion: v1
+data:
+  metrics.properties: |
+    rules:
+    # Special cases and very specific rules
+    - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+      name: kafka_server_$1_$2
+      type: GAUGE
+      labels:
+        clientId: "$3"
+        topic: "$4"
+        partition: "$5"
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2019-10-21T17:45:41Z"
+  name: metrics-config
+  namespace: kudo-kafka
+  resourceVersion: "74591"
+  selfLink: /api/v1/namespaces/kudo-kafka/configmaps/metrics-config
+  uid: 70273127-e9d6-4e36-ba9a-0e00c78dfe51
+```
+
+Now we are ready to start the KUDO Kafka cluster with custom metrics reporter configuration
+
+```
+> kubectl kudo install kafka \
+    --instance=kafka --namespace=kudo-kafka \
+    -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
+    -p BROKER_COUNT=3 \
+    -p CUSTOM_METRICS_CM_NAME=metrics-config
+```
+
+Verify that brokers have the correct metrics reporter configuration
+
+```
+> kubectl exec -ti kafka-kafka-0 cat /metrics/metrics.properties
+rules:
+    # Special cases and very specific rules
+    - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+      name: kafka_server_$1_$2
+      type: GAUGE
+      labels:
+        clientId: "$3"
+        topic: "$4"
+        partition: "$5"
+```
+
+#### Updating the custom metrics reporter 
+
+Like the custom configuration the custom metrics reporter is also not watched by the KUDO controller. Therefore to any updates done in the custom configuration will need a later rolling restart.
+
+Edit the configmap with changes we want to rollout:
+
+```
+> kubectl edit configmap metrics-config -n kudo-kafka
+configmap/metrics-config edited
+```
+
+Perform a rolling restart on the statefulset to reload the configmap.
+
+```
+> kubectl rollout restart statefulset kafka-kafka -n kudo-kafka
+statefulset.apps/kafka-kafka restarted
+```

--- a/repository/kafka/docs/latest/custom.md
+++ b/repository/kafka/docs/latest/custom.md
@@ -96,7 +96,14 @@ statefulset.apps/kafka-kafka restarted
 
 #### :warning: Excludelist of the custom configuration
 
-Users can update all the broker configuration properties except the `broker.id`, `listeners`,`advertised.listeners`,  `advertised.host.name`,  `listener.security.protocol.map` `log.dirs`
+Users can update all the broker configuration properties except the following:
+ - `broker.id`
+ - `listeners`
+ - `advertised.listeners`
+ - `advertised.host.name`
+ - `listener.security.protocol.map`
+ - `log.dirs`
+ 
 ## Custom metrics reporter 
 
 To use the custom metrics reporter configuration we need to create a configmap with the `metrics.yaml` we want to override.

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -746,3 +746,13 @@ CUSTOM_SERVER_PROPERTIES:
   displayName: "custom server properties"
   description: "These properties will be appended to the Kafka server properties"
   default: ""
+
+CUSTOM_SERVER_PROPERTIES_CM_NAME:
+  displayName: "custom server properties configmap name"
+  description: "The properties present in this configmap will be appended to the Kafka server properties"
+  required: false
+
+CUSTOM_METRICS_CM_NAME:
+  displayName: "custom metrics properties and rules"
+  description: "These metrics prometheus rules to be used instead of the default metrics rules."
+  required: false

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -135,3 +135,25 @@ data:
     # Provided configuration
     ${KAFKA_CONFIGURATION}
     EOF
+
+    {{ if .Params.CUSTOM_SERVER_PROPERTIES_CM_NAME }}
+    KAFKA_CUSTOM_CONFIGURATION_FILE=$(ls -d /custom-configuration/* | head -n 1)
+    cp $KAFKA_CUSTOM_CONFIGURATION_FILE /tmp/custom-configuration
+    echo "Appending custom configuration file to the server.properties..." | xargs -L 1 echo $(date +'[%Y-%m-%d %H:%M:%S,%3N]') $1
+
+    # remove blacklisted properties that users cannot override
+    skip_properties=("broker.id" "listeners" "advertised.listeners" "advertised.host.name" "listener.security.protocol.map" "log.dirs")
+    for property in "${skip_properties[@]}"; do
+    	if grep -q $property /tmp/custom-configuration; then
+      		echo "WARN: cannot override the $property using custom properties configmap.";
+      		echo "Removing property $property"
+      		sed -i "/^$property/d" /tmp/custom-configuration
+    	fi
+    done
+
+    KAFKA_CUSTOM_CONFIGURATION=$(cat /tmp/custom-configuration)
+    cat /tmp/custom-configuration
+    cat >> ${KAFKA_HOME}/server.properties <<EOF
+    ${KAFKA_CUSTOM_CONFIGURATION}
+    EOF
+    {{ end }}

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -142,7 +142,7 @@ data:
     echo "Appending custom configuration file to the server.properties..." | xargs -L 1 echo $(date +'[%Y-%m-%d %H:%M:%S,%3N]') $1
 
     # remove blacklisted properties that users cannot override
-    skip_properties=("broker.id" "listeners" "advertised.listeners" "advertised.host.name" "listener.security.protocol.map" "log.dirs")
+    skip_properties=("broker.id=" "listeners=" "advertised.listeners=" "advertised.host.name=" "listener.security.protocol.map=" "log.dirs=")
     for property in "${skip_properties[@]}"; do
     	if grep -q $property /tmp/custom-configuration; then
       		echo "WARN: cannot override '$property' using custom properties configmap.";

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -145,8 +145,8 @@ data:
     skip_properties=("broker.id" "listeners" "advertised.listeners" "advertised.host.name" "listener.security.protocol.map" "log.dirs")
     for property in "${skip_properties[@]}"; do
     	if grep -q $property /tmp/custom-configuration; then
-      		echo "WARN: cannot override the $property using custom properties configmap.";
-      		echo "Removing property $property"
+      		echo "WARN: cannot override '$property' using custom properties configmap.";
+      		echo "Removing property '$property'"
       		sed -i "/^$property/d" /tmp/custom-configuration
     	fi
     done

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -152,7 +152,7 @@ data:
     done
 
     KAFKA_CUSTOM_CONFIGURATION=$(cat /tmp/custom-configuration)
-    cat /tmp/custom-configuration
+    echo ${KAFKA_CUSTOM_CONFIGURATION}
     cat >> ${KAFKA_HOME}/server.properties <<EOF
     ${KAFKA_CUSTOM_CONFIGURATION}
     EOF

--- a/repository/kafka/operator/templates/bootstrap.yaml
+++ b/repository/kafka/operator/templates/bootstrap.yaml
@@ -142,13 +142,16 @@ data:
     echo "Appending custom configuration file to the server.properties..." | xargs -L 1 echo $(date +'[%Y-%m-%d %H:%M:%S,%3N]') $1
 
     # remove blacklisted properties that users cannot override
-    skip_properties=("broker.id=" "listeners=" "advertised.listeners=" "advertised.host.name=" "listener.security.protocol.map=" "log.dirs=")
+    skip_properties=("broker.id" "listeners" "advertised.listeners" "advertised.host.name" "listener.security.protocol.map" "log.dirs")
     for property in "${skip_properties[@]}"; do
-    	if grep -q $property /tmp/custom-configuration; then
-      		echo "WARN: cannot override '$property' using custom properties configmap.";
-      		echo "Removing property '$property'"
-      		sed -i "/^$property/d" /tmp/custom-configuration
-    	fi
+      # grep and sed commands are using the '=' suffix to make sure we don't remove any
+      # properties containing the 'skip_properties' strings
+      # e.g 'broker.id=1' should be removed but 'broker.id.subkey=a' should not be removed
+      if grep -q "${property}=" /tmp/custom-configuration; then
+        echo "WARN: cannot override '$property' using custom properties configmap.";
+        echo "Removing property '$property'"
+        sed -i "/^${property}=/d" /tmp/custom-configuration
+      fi
     done
 
     KAFKA_CUSTOM_CONFIGURATION=$(cat /tmp/custom-configuration)

--- a/repository/kafka/operator/templates/metrics-config.yaml
+++ b/repository/kafka/operator/templates/metrics-config.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: 2016-03-30T18:14:41Z
   name: metrics-config
 data:
   metrics.properties: |

--- a/repository/kafka/operator/templates/server.properties.yaml
+++ b/repository/kafka/operator/templates/server.properties.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: 2016-03-30T18:14:41Z
   name: serverproperties
 data:
   server.properties: |
@@ -282,5 +281,3 @@ data:
 
     zookeeper.session.timeout.ms={{ .Params.ZOOKEEPER_SESSION_TIMEOUT_MS }}
     zookeeper.sync.time.ms={{ .Params.ZOOKEEPER_SYNC_TIME_MS }}
-
-    {{ .Params.CUSTOM_SERVER_PROPERTIES }}

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -90,6 +90,10 @@ spec:
             - name: metrics
               mountPath: /metrics
           {{ end }}
+          {{ if .Params.CUSTOM_SERVER_PROPERTIES_CM_NAME }}
+            - name: custom-configuration
+              mountPath: /custom-configuration
+          {{ end }}
           {{ if eq .Params.KERBEROS_ENABLED "true" }}
             - name: jass-config
               mountPath: /jass-config
@@ -149,10 +153,19 @@ spec:
             name: {{ .Name }}-serverproperties
         - name: metrics
           configMap:
+            {{ if .Params.CUSTOM_METRICS_CM_NAME }}
+            name: {{ .Params.CUSTOM_METRICS_CM_NAME }}
+            {{ else }}
             name: {{ .Name }}-metrics-config
+            {{ end }}
         - name: health-check-script
           configMap:
             name: {{ .Name }}-health-check-script
+        {{ if .Params.CUSTOM_SERVER_PROPERTIES_CM_NAME }}
+        - name: custom-configuration
+          configMap:
+            name: {{ .Params.CUSTOM_SERVER_PROPERTIES_CM_NAME }}
+        {{ end }}
         {{ if eq .Params.KERBEROS_ENABLED "true" }}
         - name: jass-config
           configMap:


### PR DESCRIPTION
This PR adds the two custom configuration parameters `CUSTOM_SERVER_PROPERTIES_CM_NAME` and `CUSTOM_METRICS_CM_NAME `

- `CUSTOM_SERVER_PROPERTIES_CM_NAME` enables adding custom broker configuration 
-  `CUSTOM_METRICS_CM_NAME` enables adding custom metrics reporter configuration 