### PR TITLE
kafka: add annotations for cm/secrets reload

### DIFF
--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     kafka: {{ .OperatorName }}
     app: kafka
+  annotations:
+    reloader.kudo.dev/auto: "true"
 spec:
   selector:
     matchLabels:

--- a/repository/zookeeper/operator/templates/statefulset.yaml
+++ b/repository/zookeeper/operator/templates/statefulset.yaml
@@ -7,6 +7,8 @@ metadata:
     zookeeper: {{ .OperatorName }}
     app: zookeeper
     instance: {{ .Name }}
+  annotations:
+    reloader.kudo.dev/auto: "true"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
this PR is to enable the rolling restart of statefulset once a cm is updated
needs https://github.com/kudobuilder/kudo/pull/996 to be working. 

This will enable updates like:
`kubectl kudo update --instance=kafka-zntnds -p MESSAGE_MAX_BYTES=100000`

that will update the `serverproperties configmap` and do a rolling restart of the sts to restart brokers with the updated configuration. 