### PR TITLE
Bump Kudo Kafka version to 1.0.0

### DIFF
--- a/repository/kafka/docs/latest/configuration.md
+++ b/repository/kafka/docs/latest/configuration.md
@@ -108,4 +108,4 @@ will create a Zookeeper node in path `/custom-path`.
 
 ##### Docker image
 
-The Dockerfile used to build the KUDO Kafka operator is hosted in the [dcos-kafka-service](https://github.com/mesosphere/dcos-kafka-service/blob/master/images/Dockerfile) repo
+The Dockerfile used to build the KUDO Kafka operator is hosted in the [dcos-kafka-service](https://github.com/mesosphere/kudo-kafka-operator/blob/master/images/Dockerfile) repo

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: k8skafka
           imagePullPolicy: Always
-          image: mesosphere/kafka:0.3.1-2.3.0
+          image: mesosphere/kafka:1.0.0-2.3.0
           resources:
             requests:
               memory: {{ .Params.BROKER_MEM }}


### PR DESCRIPTION
Docker Hub Image: https://hub.docker.com/layers/mesosphere/kafka/1.0.0-2.3.0/images/sha256-a40cbacc01a27104d2dcad627b58b239d8ca764a5016efaca1f0245e80aac301