### PR TITLE
Update Deployment apiVersion to apps/v1 in Flink

### DIFF
--- a/repository/flink/docs/demo/financial-fraud/README.md
+++ b/repository/flink/docs/demo/financial-fraud/README.md
@@ -1,6 +1,6 @@
 # Flink Financial Fraud Demo
 
-This demo follows the outline provided by [DCOS's](https://github.com/dcos/demos/tree/master/flink-k8s/1.11) demo
+This demo follows the outline provided by [DC/OS's](https://github.com/dcos/demos/tree/master/flink-k8s/1.11) demo
 
 ### Architecture
 
@@ -41,41 +41,35 @@ For [minikube](https://github.com/kubernetes/minikube):
 minikube start --vm-driver=hyperkit --cpus=6 --memory=9216 --disk-size=10g
 ```
 
-- Have current KUDO CLI `v0.6.x` or higher [installed](https://kudo.dev/docs/cli/#install)
+- Have current KUDO CLI `v0.7.x` or higher [installed](https://kudo.dev/docs/cli/#install)
     - Run `kubectl kudo version`, the output should look like:
     ```bash
-    KUDO Version: version.Info{GitVersion:"0.6.0", GitCommit:"c048b759", BuildDate:"2019-09-17T14:03:04Z", GoVersion:"go1.13", Compiler:"gc", Platform:"darwin/amd64"}
+    KUDO Version: version.Info{GitVersion:"0.7.5", GitCommit:"45fe3dad", BuildDate:"2019-10-18T14:07:37Z", GoVersion:"go1.13", Compiler:"gc", Platform:"darwin/amd64"}
     ```
     - If not, upgrade to the latest version via `brew upgrade kudo-cli`
-- Have current KUDO `v0.6.x` or higher installed on your cluster:
+- Have current KUDO `v0.7.x` or higher installed on your cluster:
     - If you have KUDO already installed to the `kudo-system` namespace check its current Docker image tag to verify the version you are running:
-        - Make sure the output of `kubectl get pod kudo-controller-manager-0 -n kudo-system -o jsonpath='{.spec.containers[0].image}'` shows at least `v0.3.3` as Docker tag:
+        - Make sure the output of `kubectl get pod kudo-controller-manager-0 -n kudo-system -o jsonpath='{.spec.containers[0].image}'` shows at least `v0.7.x` as Docker tag:
         ```bash
         $ kubectl get pod kudo-controller-manager-0 -n kudo-system -o jsonpath='{.spec.containers[0].image}'
-        kudobuilder/controller:v0.3.3
+        kudobuilder/controller:v0.7.5
         ```
-    - If not, use the following commands to install KUDO `v0.6.0` to your cluster:
+    - If not, use the following commands to install KUDO `v0.7.x` to your cluster:
         - `kubectl kudo init`
 - Have the `zookeeper` Operator with `0.1.0` as OperatorVersion installed
     - Use the KUDO CLI with the following command:
         ```bash
         $ kubectl kudo install zookeeper --version=0.1.0 --skip-instance
-        operator.kudo.dev/v1alpha1/zookeeper created
-        operatorversion.kudo.dev/v1alpha1/zookeeper-0.1.0 created
         ```
 - Have the `kafka` Operator with `0.1.2` as OperatorVersion installed
     - Use the KUDO CLI with the following command:
         ```bash
         $ kubectl kudo install kafka --version=0.1.2 --skip-instance
-        operator.kudo.dev/v1alpha1/kafka created
-        operatorversion.kudo.dev/v1alpha1/kafka-0.1.2 created
         ```
-- Have the `flink` Operator with `0.1.0` as OperatorVersion installed
+- Have the `flink` Operator with `0.1.1` as OperatorVersion installed
     - Use the KUDO CLI with the following command:
         ```bash
-        $ kubectl kudo install flink --version=0.1.0 --skip-instance
-        operator.kudo.dev/v1alpha1/flink created
-        operatorversion.kudo.dev/v1alpha1/flink-0.1.0 created
+        $ kubectl kudo install flink --version=0.1.1 --skip-instance
         ```
 
 Now you should have all required Operators installed.
@@ -89,9 +83,6 @@ Install the Flink `financial-fraud` demo from the main repository directory.
     - Install the Flink demo objects straight out of the repository:
         ```
         $ kubectl kudo install repository/flink/docs/demo/financial-fraud/demo-operator --instance flink-demo
-        operator.kudo.dev/v1alpha1/flink-demo created
-        operatorversion.kudo.dev/v1alpha1/flink-demo-0.1.0 created
-        No instance named 'flink-demo' tied to this 'flink-demo' version has been found. Do you want to create one? (Yes/no) yes
         instance.kudo.dev/v1alpha1/flink-demo created
         ```
 
@@ -151,7 +142,7 @@ Lastly, the Flink operator needs to be installed. We wait for its status to be c
 $ kubectl kudo plan status --instance flink-demo-flink
 Plan(s) for "flink-demo-flink" in namespace "default":
 .
-└── flink-demo-flink (Operator-Version: "flink-0.1.0" Active-Plan: "flink-demo-flink-deploy-520884487")
+└── flink-demo-flink (Operator-Version: "flink-0.1.1" Active-Plan: "flink-demo-flink-deploy-520884487")
     └── Plan deploy (serial strategy) [COMPLETE]
         └── Phase flink (serial strategy) [COMPLETE]
             └── Step jobmanager (COMPLETE)
@@ -164,7 +155,7 @@ Flink demo:
 $ kubectl kudo plan status --instance flink-demo
 Plan(s) for "flink-demo" in namespace "default":
 .
-└── flink-demo (Operator-Version: "flink-demo-0.1.0" Active-Plan: "flink-demo-deploy-144875020")
+└── flink-demo (Operator-Version: "flink-demo-0.1.1" Active-Plan: "flink-demo-deploy-144875020")
     └── Plan deploy (serial strategy) [COMPLETE]
         ├── Phase dependencies (serial strategy) [COMPLETE]
         │   ├── Step zookeeper (COMPLETE)

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/operator.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/operator.yaml
@@ -1,5 +1,5 @@
 name: "flink-demo"
-version: "0.1.0"
+version: "0.1.1"
 kudoVersion: 0.3.0
 kubernetesVersion: 1.15.0
 maintainers:

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/actor.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/actor.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: actor

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/flink.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/flink.yaml
@@ -8,7 +8,7 @@ metadata:
   name: flink
 spec:
   operatorVersion:
-    name: flink-0.1.0
+    name: flink-0.1.1
     namespace: default
     type: OperatorVersions
   parameters:

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/generator.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/generator.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: generator

--- a/repository/flink/docs/demo/modifications/flinkcluster-frameworkversion.yaml
+++ b/repository/flink/docs/demo/modifications/flinkcluster-frameworkversion.yaml
@@ -101,7 +101,7 @@ spec:
           component: {{NAME}}-jobmanager
         clusterIP: None
     taskmanager-deployment.yaml: |
-      apiVersion: extensions/v1beta1
+      apiVersion: apps/v1
       kind: Deployment
       metadata:
         name: taskmanager

--- a/repository/flink/operator/operator.yaml
+++ b/repository/flink/operator/operator.yaml
@@ -1,5 +1,5 @@
 name: "flink"
-version: "0.1.0"
+version: "0.1.1"
 kudoVersion: 0.3.0
 kubernetesVersion: 1.15.0
 appVersion: 1.7.2

--- a/repository/flink/operator/templates/taskmanager-deployment.yaml
+++ b/repository/flink/operator/templates/taskmanager-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskmanager


### PR DESCRIPTION
Since Kubernetes 1.16 the only supported `apiVersion` for `Deployment` is `apps/v1` ([see announcement](https://kubernetes.io/blog/2019/09/18/kubernetes-1-16-release-announcement/)). It was introduced in 1.9. This PR updates the Flink operator and demo to use the new apiVersion, bumps the operator version of Flink and the demo, and updates the demo instructions accordingly. 