### PR TITLE
zookeeper: add not-allowed plan to avoid updating storage options

### DIFF
--- a/repository/zookeeper/operator/operator.yaml
+++ b/repository/zookeeper/operator/operator.yaml
@@ -22,6 +22,8 @@ tasks:
   validation:
     resources:
       - validation.yaml
+  not-allowed:
+    resources:
 plans:
   deploy:
     strategy: serial

--- a/repository/zookeeper/operator/params.yaml
+++ b/repository/zookeeper/operator/params.yaml
@@ -14,10 +14,12 @@ CPUS:
 STORAGE_CLASS:
   description: "The storage class to be used in volumeClaimTemplates. By default its not required and the default storage class is used."
   required: false
+  trigger: "not-allowed"
 
 DISK_SIZE:
   description: "Disk size for the Zookeeper servers"
   default: "5Gi"
+  trigger: "not-allowed"
 
 CLIENT_PORT:
   default: "2181"


### PR DESCRIPTION
we still don't have immutable parameters feature in KUDO so we have to add the work around of `not-allowed` to zookeeper also
Here is the issue: https://github.com/kudobuilder/kudo/issues/652

Lets update the zookeeper and kafka operators once we can specify the immutable parameters 