### PR TITLE
kafka: fix tls features

### DIFF
--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -21,6 +21,7 @@ tasks:
         - bootstrap.yaml
         - metrics-config.yaml
         - health-check.yaml
+        - enable-tls.yaml
         - jaas-config.yaml
         - krb5-config.yaml
         - statefulset.yaml
@@ -34,6 +35,7 @@ tasks:
         - bootstrap.yaml
         - metrics-config.yaml
         - health-check.yaml
+        - enable-tls.yaml
         - jaas-config.yaml
         - krb5-config.yaml
         - statefulset.yaml


### PR DESCRIPTION
add back the `enable-tls.yaml` to the update and deploy tasks for Kafka