### PR TITLE
[ZooKeeper] Ensure cleanup task is run post-validation during deploy phase

### DIFF
--- a/repository/zookeeper/operator/operator.yaml
+++ b/repository/zookeeper/operator/operator.yaml
@@ -50,11 +50,14 @@ plans:
               - infra
               - app
       - name: validation
-        strategy: parallel
+        strategy: serial
         steps:
           - name: validation
             tasks:
               - validation
+          - name: cleanup
+            tasks:
+              - validation-cleanup
   validation:
     strategy: serial
     phases:


### PR DESCRIPTION
This ensures that the pod for the validation job doesn't linger once deployment has completed successfully.