### PR TITLE
[Kafka] Omit instance name to simplify installation process

### DIFF
--- a/repository/kafka/docs/latest/install.md
+++ b/repository/kafka/docs/latest/install.md
@@ -12,7 +12,7 @@ To run a production-grade KUDO Kafka cluster, please read [KUDO Kafka in product
 
 #### Install Zookeeper 
 ```
-kubectl kudo install zookeeper --instance=zk
+kubectl kudo install zookeeper
 ```
 
 #### Install Kafka 
@@ -20,18 +20,22 @@ kubectl kudo install zookeeper --instance=zk
 Please read the [limitations](./limitations.md) docs before creating the KUDO Kafka cluster. 
 
 ```
-kubectl kudo install kafka --instance=kafka
+kubectl kudo install kafka
 ```
 
-Verify the if the deploy plan for `--instance=kafka` is complete.
+Verify the if the deploy plan for `--instance=kafka-instance` is complete.
 ```
-kubectl kudo plan status --instance=kafka
-Plan(s) for "kafka" in namespace "default":
+kubectl kudo plan status --instance=kafka-instance
+Plan(s) for "kafka-instance" in namespace "default":
 .
-└── kafka (Operator-Version: "kafka-0.1.2" Active-Plan: "kafka-deploy-177524647")
-    └── Plan deploy (serial strategy) [COMPLETE]
-        └── Phase deploy-kafka (serial strategy) [COMPLETE]
-            └── Step deploy (COMPLETE)
+└── kafka-instance (Operator-Version: "kafka-1.0.0" Active-Plan: "deploy")
+    ├── Plan deploy (serial strategy) [COMPLETE]
+    │  └── Phase deploy-kafka [COMPLETE]
+    │    └── Step deploy (COMPLETE)
+    └── Plan not-allowed (serial strategy) [NOT ACTIVE]
+        └── Phase not-allowed (serial strategy) [NOT ACTIVE]
+            └── Step not-allowed (serial strategy) [NOT ACTIVE]
+                └── not-allowed [NOT ACTIVE]
 ```
 
 You can view all configuration options [here](./configuration.md)

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -64,7 +64,7 @@ parameters:
     description: |
       host and port information for Zookeeper connection.
       e.g. zk:2181,zk2:2181,zk3:2181
-    default: "zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181"
+    default: "zookeeper-instance-zookeeper-0.zookeeper-instance-hs:2181,zookeeper-instance-zookeeper-1.zookeeper-instance-hs:2181,zookeeper-instance-zookeeper-2.zookeeper-instance-hs:2181"
     required: true
   - name: ZOOKEEPER_PATH
     displayName: "zookeeper node path"


### PR DESCRIPTION
With the introduction of [deterministic instance names](https://github.com/kudobuilder/kudo/pull/960) we can simplify some of the starting defaults such as the connection string for ZooKeeper.