### PR TITLE
kafka: add TCP option for Kerberos

### DIFF
--- a/repository/kafka/docs/latest/security.md
+++ b/repository/kafka/docs/latest/security.md
@@ -92,7 +92,8 @@ kubectl kudo install kafka \
     -p KERBEROS_REALM=LOCAL\
     -p KERBEROS_KDC_HOSTNAME=kdc-service.kudo-kafka.svc.cluster.local \
     -p KERBEROS_KDC_PORT=2500 \
-    -p KERBEROS_KEYTAB_SECRET="base64-kafka-keytab-secret"
+    -p KERBEROS_KEYTAB_SECRET="base64-kafka-keytab-secret" \
+    -p KERBEROS_USE_TCP=true
 ```
 then the principals to create would be:
 ```
@@ -100,9 +101,16 @@ kafka/kafka-kafka-0.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
 kafka/kafka-kafka-1.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
 kafka/kafka-kafka-2.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
 ```
+
+Use `KERBEROS_USE_TCP=true` parameter to use `TCP` protocol for KDC. By default it will try to use UDP. 
 #### Place Service Keytab in Kubernetes Secret Store
 
 The KUDO Kafka service uses a keytab containing all node principals (service keytab). After creating the principals above, generate the service keytab making sure to include all the node principals. This should be stored as a secret in the Kubernetes Secret Store using `base64` encoding.
+
+```
+kubectl create secret generic kdc --from-file=./kafka.keytab
+```
+:warning: The KUDO Kafka assume the key in the secret to be `kafka.keytab`
 
 ## Authorization
 

--- a/repository/kafka/docs/v1.0/release-notes.md
+++ b/repository/kafka/docs/v1.0/release-notes.md
@@ -1,6 +1,10 @@
 # Release notes 
 
 
+## v1.0.2
+
+- Add parameter `KERBEROS_USE_TCP` to use TCP protocol for KDC connection
+
 ## v1.0.1
 
 - Apache Kafka upgraded to 2.3.1

--- a/repository/kafka/docs/v1.0/security.md
+++ b/repository/kafka/docs/v1.0/security.md
@@ -92,7 +92,8 @@ kubectl kudo install kafka \
     -p KERBEROS_REALM=LOCAL\
     -p KERBEROS_KDC_HOSTNAME=kdc-service.kudo-kafka.svc.cluster.local \
     -p KERBEROS_KDC_PORT=2500 \
-    -p KERBEROS_KEYTAB_SECRET="base64-kafka-keytab-secret"
+    -p KERBEROS_KEYTAB_SECRET="base64-kafka-keytab-secret" \
+    -p KERBEROS_USE_TCP=true
 ```
 then the principals to create would be:
 ```
@@ -100,9 +101,16 @@ kafka/kafka-kafka-0.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
 kafka/kafka-kafka-1.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
 kafka/kafka-kafka-2.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
 ```
+
+Use `KERBEROS_USE_TCP=true` parameter to use `TCP` protocol for KDC. By default it will try to use UDP. 
 #### Place Service Keytab in Kubernetes Secret Store
 
 The KUDO Kafka service uses a keytab containing all node principals (service keytab). After creating the principals above, generate the service keytab making sure to include all the node principals. This should be stored as a secret in the Kubernetes Secret Store using `base64` encoding.
+
+```
+kubectl create secret generic kdc --from-file=./kafka.keytab
+```
+:warning: The KUDO Kafka assume the key in the secret to be `kafka.keytab`
 
 ## Authorization
 

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -1,6 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 name: "kafka"
-version: "1.0.1"
+version: "1.0.2"
 kudoVersion: 0.8.0
 kubernetesVersion: 1.14.8
 appVersion: 2.3.1

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -117,6 +117,10 @@ parameters:
     description: "The port of the host running a KDC for that realm."
     default: "2500"
     displayName: "Kerberos Port"
+  - name: KERBEROS_USE_TCP
+    description: "Use TCP for KDC connection, by default it uses UDP protocol"
+    default: "false"
+    displayName: "Use TCP for Kerberos"
   - name: KERBEROS_DEBUG
     description: "Turn debug Kerberos logging on or off to assist in diagnosing issues with Kerberos authentication."
     default: "false"

--- a/repository/kafka/operator/templates/krb5-config.yaml
+++ b/repository/kafka/operator/templates/krb5-config.yaml
@@ -7,6 +7,9 @@ data:
   krb5.conf: |
     [libdefaults]
     default_realm = {{ .Params.KERBEROS_REALM }}
+    {{ if eq .Params.KERBEROS_USE_TCP "true" }}
+    udp_preference_limit = 1
+    {{ end }}
 
     [realms]
     {{ .Params.KERBEROS_REALM }} = {


### PR DESCRIPTION
add `KERBEROS_USE_TCP` option to use it with KDC servers that only accept TCP connections