### PR TITLE
kafka: add MirrorMaker integration

### DIFF
--- a/repository/kafka/docs/latest/mirrormaker.md
+++ b/repository/kafka/docs/latest/mirrormaker.md
@@ -1,8 +1,8 @@
 
 # Kafka MirrorMaker
 
-KUDO Kafka operator comes with [Kafka MirrorMaker](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330) included. MirrorMaker is a tool to mirror a source Kafka 
-cluster into a target (mirror) Kafka cluster. The tool uses a Kafka consumer to consume messages from the
+KUDO Kafka operator comes with builtin integration of [Kafka MirrorMaker](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330).
+MirrorMaker is a tool to mirror a source Kafka cluster into a target (mirror) Kafka cluster. The tool uses a Kafka consumer to consume messages from the
 source cluster, and re-publishes those messages to the (target) cluster using an embedded Kafka producer.
 
 ### Using the MirrorMaker

--- a/repository/kafka/docs/latest/mirrormaker.md
+++ b/repository/kafka/docs/latest/mirrormaker.md
@@ -43,3 +43,9 @@ kubectl kudo update --instance=kafka -p MIRROR_MAKER_REPLICA_COUNT=0
 |MIRROR_MAKER_NUM_STREAMS|Number of consumer streams|<ul><li>"1" (default)</li></ul>|
 |MIRROR_MAKER_OFFSET_COMMIT_INTERVAL|Offset commit interval in ms|<ul><li>"60000" for 1 min (default)</li></ui>|
 |MIRROR_MAKER_ABORT_ON_SEND_FAILURE| Stop the entire mirror maker when a send failure occurs |<ul><li>"true" (default)</li><li>"false"</li></ul>|
+
+### Limitations
+
+Currently MirrorMaker works with Kafka protocol `PLAINTEXT` only. It will not work if Kerberos and or TLS is
+enabled in the Kafka instance (external included). Future releases of KUDO Kafka will provide enhancements to
+address this limitation through a MirrorMaker operator.

--- a/repository/kafka/docs/latest/mirrormaker.md
+++ b/repository/kafka/docs/latest/mirrormaker.md
@@ -32,14 +32,14 @@ If MirrorMaker is running in a Kafka operator instance then to disable that scal
 pod count to 0, using the following command:
 
 ```sh
-kubectl kudo update --instance=kafkao -p MIRROR_MAKER_REPLICA_COUNT=0
+kubectl kudo update --instance=kafka -p MIRROR_MAKER_REPLICA_COUNT=0
 ``` 
 
 ### Advanced Options
 
-|Parameter|Description|
-|--|--|
-| MIRROR_MAKER_TOPIC_WHITELIST | Whitelist of topics to mirror |
-|MIRROR_MAKER_NUM_STREAMS|Number of consumer streams|
-|MIRROR_MAKER_OFFSET_COMMIT_INTERVAL|Offset commit interval in ms|
-|MIRROR_MAKER_ABORT_ON_SEND_FAILURE| Stop the entire mirror maker when a send failure occurs |
+|Parameter|Description|Example|
+|--|--|--|
+| MIRROR_MAKER_TOPIC_WHITELIST | Whitelist of topics to mirror |<ul> <li> ".*" for all topics (default) <li>"topic1"</li> <li> "topic5,topic6"</li></ul> |
+|MIRROR_MAKER_NUM_STREAMS|Number of consumer streams|<ul><li>"1" (default)</li></ul>|
+|MIRROR_MAKER_OFFSET_COMMIT_INTERVAL|Offset commit interval in ms|<ul><li>"60000" for 1 min (default)</li></ui>|
+|MIRROR_MAKER_ABORT_ON_SEND_FAILURE| Stop the entire mirror maker when a send failure occurs |<ul><li>"true" (default)</li><li>"false"</li></ul>|

--- a/repository/kafka/docs/latest/mirrormaker.md
+++ b/repository/kafka/docs/latest/mirrormaker.md
@@ -1,0 +1,45 @@
+
+# Kafka MirrorMaker
+
+KUDO Kafka operator comes with [Kafka MirrorMaker](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330) included. MirrorMaker is a tool to mirror a source Kafka 
+cluster into a target (mirror) Kafka cluster. The tool uses a Kafka consumer to consume messages from the
+source cluster, and re-publishes those messages to the (target) cluster using an embedded Kafka producer.
+
+### Using the MirrorMaker
+
+To start MirrorMaker install the Kafka operator with the following options:
+
+```sh
+kubectl kudo install kafka --instance=kafka \
+  -p MIRROR_MAKER_ENABLED=true \
+  -p MIRROR_MAKER_EXTERNAL_BOOTSTRAP_SERVERS=<external-kafka-cluster-address>\
+  -p MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE=SOURCE
+```
+
+Parameter `MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE` takes one of two values:
+
+1. `SOURCE`: The Kafka cluster defined by `MIRROR_MAKER_EXTERNAL_BOOTSTRAP_SERVERS` will be
+   used as a source cluster from which MirrorMaker will consume all the topics and produce those
+   to our `kafka` cluster instance.
+
+2. `DESTINATION`: MirrorMaker will consume topics from `kafka` cluster instance and produce those
+   to the cluster defined by `MIRROR_MAKER_EXTERNAL_BOOTSTRAP_SERVERS`.
+
+
+### Disable MirrorMaker
+
+If MirrorMaker is running in a Kafka operator instance then to disable that scale the MirrorMaker
+pod count to 0, using the following command:
+
+```sh
+kubectl kudo update --instance=kafkao -p MIRROR_MAKER_REPLICA_COUNT=0
+``` 
+
+### Advanced Options
+
+|Parameter|Description|
+|--|--|
+| MIRROR_MAKER_TOPIC_WHITELIST | Whitelist of topics to mirror |
+|MIRROR_MAKER_NUM_STREAMS|Number of consumer streams|
+|MIRROR_MAKER_OFFSET_COMMIT_INTERVAL|Offset commit interval in ms|
+|MIRROR_MAKER_ABORT_ON_SEND_FAILURE| Stop the entire mirror maker when a send failure occurs |

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -41,6 +41,12 @@ tasks:
         - jaas-config.yaml
         - krb5-config.yaml
         - statefulset.yaml
+  - name: mirrormaker
+    kind: Apply
+    spec:
+      resources:
+        - mirror-maker-config.yaml
+        - mirror-maker.yaml
   - name: not-allowed
     kind: Apply
     spec:
@@ -55,6 +61,15 @@ plans:
           - name: deploy
             tasks:
               - deploy
+  mirrormaker:
+    strategy: serial
+    phases:
+      - name: deploy-mirror-maker
+        strategy: serial
+        steps:
+          - name: deploy
+            tasks:
+              - mirrormaker
   # this plan is triggered when some parameter present in limitations is updated
   # https://github.com/kudobuilder/operators/blob/master/repository/kafka/docs/latest/limitations.md
   not-allowed:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -616,3 +616,24 @@ parameters:
     displayName: "custom metrics properties and rules"
     description: "These metrics prometheus rules to be used instead of the default metrics rules."
     required: false
+  - name: MIRROR_MAKER_ENABLED
+    default: "false"
+    trigger: "mirrormaker"
+  - name: MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE
+    default: "SOURCE"
+    trigger: "mirrormaker"
+  - name: MIRROR_MAKER_EXTERNAL_BOOTSTRAP_SERVERS
+    default: ""
+    trigger: "mirrormaker"
+  - name: MIRROR_MAKER_ABORT_ON_SEND_FAILURE
+    default: "true"
+    trigger: "mirrormaker"
+  - name: MIRROR_MAKER_TOPIC_WHITELIST
+    default: ".*"
+    trigger: "mirrormaker"
+  - name: MIRROR_MAKER_NUM_STREAMS
+    default: "1"
+    trigger: "mirrormaker"
+  - name: MIRROR_MAKER_OFFSET_COMMIT_INTERVAL
+    default: "60000"
+    trigger: "mirrormaker"

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -630,15 +630,19 @@ parameters:
     trigger: "mirrormaker"
   - name: MIRROR_MAKER_ABORT_ON_SEND_FAILURE
     default: "true"
+    description: "Configure the mirror maker to exit on a failed send"
     trigger: "mirrormaker"
   - name: MIRROR_MAKER_TOPIC_WHITELIST
     default: ".*"
+    description: "Whitelist of topics to mirror"
     trigger: "mirrormaker"
   - name: MIRROR_MAKER_NUM_STREAMS
     default: "1"
+    description: "Number of consumer streams to use to consume topics from the source cluster"
     trigger: "mirrormaker"
   - name: MIRROR_MAKER_OFFSET_COMMIT_INTERVAL
     default: "60000"
+    description: "Offset commit interval in ms"
     trigger: "mirrormaker"
   - name: MIRROR_MAKER_CPUS
     description: "CPUs (request) for the Mirror Maker pods. spec.containers[].resources.requests.cpu"

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -619,6 +619,9 @@ parameters:
   - name: MIRROR_MAKER_ENABLED
     default: "false"
     trigger: "mirrormaker"
+  - name: MIRROR_MAKER_REPLICA_COUNT
+    default: "1"
+    trigger: "mirrormaker"
   - name: MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE
     default: "SOURCE"
     trigger: "mirrormaker"
@@ -637,3 +640,15 @@ parameters:
   - name: MIRROR_MAKER_OFFSET_COMMIT_INTERVAL
     default: "60000"
     trigger: "mirrormaker"
+  - name: MIRROR_MAKER_CPUS
+    description: "CPUs (request) for the Mirror Maker pods. spec.containers[].resources.requests.cpu"
+    default: "100m"
+  - name: MIRROR_MAKER_CPUS_LIMIT
+    description: "CPUs (limit) for the Mirror Maker pods. spec.containers[].resources.limits.cpu"
+    default: "100m"
+  - name: MIRROR_MAKER_MEM
+    description: "Memory (request) for the Mirror Maker pods. spec.containers[].resources.requests.memory"
+    default: "512Mi"
+  - name: MIRROR_MAKER_MEM_LIMIT
+    description: "Memory (limit) for the Mirror Maker pods. spec.containers[].resources.limits.memory"
+    default: "512Mi"

--- a/repository/kafka/operator/templates/mirror-maker-config.yaml
+++ b/repository/kafka/operator/templates/mirror-maker-config.yaml
@@ -1,0 +1,34 @@
+{{ if eq .Params.MIRROR_MAKER_ENABLED "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Name }}-mirror-maker-config
+  namespace: {{ .Namespace }}
+data:
+  external.properties: |
+    bootstrap.servers={{ .Params.MIRROR_MAKER_EXTERNAL_BOOTSTRAP_SERVERS }}
+    {{ if eq .Params.MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE "SOURCE" }}
+    # Used when MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE is SOURCE
+    exclude.internal.topics=true
+    group.id={{ .Name }}_mirror_maker_consumer
+    auto.offset.reset=earliest
+    {{ else }}
+    # Used when MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE is DESTINATION
+    acks=1
+    batch.size=100
+    client.id={{ .Name }}_mirror_maker_producer
+    {{ end }}
+  self.properties: |
+    bootstrap.servers={{ .Name }}-svc.{{ .Namespace }}.svc.cluster.local:{{ .Params.BROKER_PORT }}
+    {{ if eq .Params.MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE "SOURCE" }}
+    # Used when MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE is DESTINATION
+    acks=1
+    batch.size=100
+    client.id={{ .Name }}_mirror_maker_producer
+    {{ else }}
+    # Used when MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE is SOURCE
+    exclude.internal.topics=true
+    group.id={{ .Name }}_mirror_maker_consumer
+    auto.offset.reset=earliest
+    {{ end }}
+{{ end }}

--- a/repository/kafka/operator/templates/mirror-maker-config.yaml
+++ b/repository/kafka/operator/templates/mirror-maker-config.yaml
@@ -21,12 +21,12 @@ data:
   self.properties: |
     bootstrap.servers={{ .Name }}-svc.{{ .Namespace }}.svc.cluster.local:{{ .Params.BROKER_PORT }}
     {{ if eq .Params.MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE "SOURCE" }}
-    # Used when MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE is DESTINATION
+    # Used when MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE is SOURCE
     acks=1
     batch.size=100
     client.id={{ .Name }}_mirror_maker_producer
     {{ else }}
-    # Used when MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE is SOURCE
+    # Used when MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE is DESTINATION
     exclude.internal.topics=true
     group.id={{ .Name }}_mirror_maker_consumer
     auto.offset.reset=earliest

--- a/repository/kafka/operator/templates/mirror-maker.yaml
+++ b/repository/kafka/operator/templates/mirror-maker.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: kafka-mirror-maker
 spec:
-  replicas: 1
+  replicas: {{ .Params.MIRROR_MAKER_REPLICA_COUNT }}
   namespaceSelector:
     matchNames:
     - {{ .Namespace }}
@@ -37,12 +37,12 @@ spec:
             --offset.commit.interval.ms={{ .Params.MIRROR_MAKER_OFFSET_COMMIT_INTERVAL }} 
             --whitelist={{ .Params.MIRROR_MAKER_TOPIC_WHITELIST }}
         resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
           requests:
-            cpu: 100m
-            memory: 512Mi
+            cpu: {{ .Params.MIRROR_MAKER_CPUS }}
+            memory: {{ .Params.MIRROR_MAKER_MEM }}
+          limits:
+            cpu: {{ .Params.MIRROR_MAKER_CPUS_LIMIT }}
+            memory: {{ .Params.MIRROR_MAKER_MEM_LIMIT }}
         volumeMounts:
           - name: mirror-maker-config
             mountPath: /mirror-maker-config

--- a/repository/kafka/operator/templates/mirror-maker.yaml
+++ b/repository/kafka/operator/templates/mirror-maker.yaml
@@ -1,0 +1,55 @@
+{{ if eq .Params.MIRROR_MAKER_ENABLED "true" }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Name }}-mirror-maker
+  namespace: {{ .Namespace }}
+  labels:
+    app: kafka-mirror-maker
+spec:
+  replicas: 1
+  namespaceSelector:
+    matchNames:
+    - {{ .Namespace }}
+  template:
+    metadata:
+      labels:
+        name: kafka-mirror-maker
+    spec:
+      containers:
+      - name: kafka-mirror-maker
+        image: mesosphere/kafka:1.0.1-2.3.1
+        imagePullPolicy: Always
+        command:
+          - bash
+          - -c
+        args:
+          - exec ${KAFKA_HOME}/bin/kafka-mirror-maker.sh \
+            {{ if eq .Params.MIRROR_MAKER_EXTERNAL_CLUSTER_TYPE "SOURCE" }}
+            --consumer.config="/mirror-maker-config/external.properties" 
+            --producer.config="/mirror-maker-config/self.properties" \
+            {{ else }}
+            --consumer.config="/mirror-maker-config/self.properties" 
+            --producer.config="/mirror-maker-config/external.properties" \
+            {{ end }}
+            --abort.on.send.failure={{ .Params.MIRROR_MAKER_ABORT_ON_SEND_FAILURE }} 
+            --num.streams={{ .Params.MIRROR_MAKER_NUM_STREAMS }} 
+            --offset.commit.interval.ms={{ .Params.MIRROR_MAKER_OFFSET_COMMIT_INTERVAL }} 
+            --whitelist={{ .Params.MIRROR_MAKER_TOPIC_WHITELIST }}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        volumeMounts:
+          - name: mirror-maker-config
+            mountPath: /mirror-maker-config
+      volumes:
+        - name: mirror-maker-config
+          configMap:
+            name: {{ .Name }}-mirror-maker-config
+  strategy:
+    type: Recreate
+{{ end }}


### PR DESCRIPTION
This PR:

- integrates [Kafka MirrorMaker](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330) with the existing Kafka operator
- adds documentation for using MirrorMaker
- solves issue https://github.com/kudobuilder/operators/issues/146