### PR TITLE
Fix mysql instance and back-pv name

### DIFF
--- a/repository/mysql/operator/params.yaml
+++ b/repository/mysql/operator/params.yaml
@@ -7,3 +7,7 @@ parameters:
     trigger: backup
   - name: PASSWORD
     default: "password"
+  - name: RESTORE_FILE
+    default: "backup.sql"
+    description: "Filename to restore the db from"
+    trigger: restore

--- a/repository/mysql/operator/templates/backup-pv.yaml
+++ b/repository/mysql/operator/templates/backup-pv.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: backup-pv
+  name: {{ .Name }}-backup-pv
 spec:
   accessModes:
     - ReadWriteOnce

--- a/repository/mysql/operator/templates/backup.yaml
+++ b/repository/mysql/operator/templates/backup.yaml
@@ -16,7 +16,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mysqldump -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} kudo > /backups/{{ .Params.BACKUP_FILE }}"
+        - "mysqldump -u root -h mysql -p{{ .Params.PASSWORD }} kudo > /backups/{{ .Params.BACKUP_FILE }}"
         volumeMounts:
         - name: backup-pv
           mountPath: /backups

--- a/repository/mysql/operator/templates/init.yaml
+++ b/repository/mysql/operator/templates/init.yaml
@@ -16,4 +16,4 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mysql -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} -e \"CREATE TABLE example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );\" kudo "
+        - "mysql -u root -h mysql -p{{ .Params.PASSWORD }} -e \"CREATE TABLE example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );\" kudo "

--- a/repository/mysql/operator/templates/mysql.yaml
+++ b/repository/mysql/operator/templates/mysql.yaml
@@ -34,6 +34,7 @@ spec:
     metadata:
       labels:
         app: mysql
+      name: mysql
     spec:
       containers:
       - image: mysql:5.7

--- a/repository/mysql/operator/templates/restore.yaml
+++ b/repository/mysql/operator/templates/restore.yaml
@@ -16,7 +16,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mysql -u root -h {{ .Name }}-mysql -p{{ .Params.PASSWORD }} --database=kudo < /backups/{{ .Params.BACKUP_FILE }}"
+        - "mysql -u root -h mysql -p{{ .Params.PASSWORD }} --database=kudo < /backups/{{ .Params.BACKUP_FILE }}"
         volumeMounts:
         - name: backup-pv
           mountPath: /backups


### PR DESCRIPTION
Mysql operator example was not working as the service name was not consistent in deploy, backup and restore plans. Apart from that, I added the param for triggering the restore plan.