### PR TITLE
Fix the bug of configmap.yaml

### DIFF
--- a/repository/redis/operator/templates/configmap.yaml
+++ b/repository/redis/operator/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redis
+  name: {{ .Name }}-redis
 data:
   update-node.sh: |
     #!/bin/sh


### PR DESCRIPTION
1. The configmap name of redis statefulset is parametered as `{{ .Name }}-redis`. See

https://github.com/kudobuilder/operators/blob/cc25204967b95b985484e7b7d639bcd52c5bcc2a/repository/redis/operator/templates/statefulset.yaml#L46

2. But in the configmap.yaml it is fixed to `redis`. See
https://github.com/kudobuilder/operators/blob/cc25204967b95b985484e7b7d639bcd52c5bcc2a/repository/redis/operator/templates/configmap.yaml#L4

When we create the instance of redis opertator, the redis statefulset can not start successfully, for name of  `configmap` is not match.