### PR TITLE
Update zookeeper and kafka OperatorVersion used in upgrade tests

### DIFF
--- a/repository/kafka/tests/kafka-upgrade-test/00-install.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/00-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk
 spec:
   operatorVersion:
-    name: zookeeper-0.2.0
+    name: zookeeper-0.3.0
     namespace: default
     kind: OperatorVersion
   name: "zk"

--- a/repository/kafka/tests/kafka-upgrade-test/01-install.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/01-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.1.0
+    name: kafka-1.2.0
     namespace: default
     kind: OperatorVersion
   name: "kafka"

--- a/repository/kafka/tests/kafka-upgrade-test/02-resize.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/02-resize.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.1.0
+    name: kafka-1.2.0
     namespace: default
     kind: OperatorVersion
   name: "kafka"

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/00-install.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/00-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk
 spec:
   operatorVersion:
-    name: zookeeper-0.2.0
+    name: zookeeper-0.3.0
     namespace: default
     kind: OperatorVersion
   name: "zk"

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/01-resize.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/01-resize.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk
 spec:
   operatorVersion:
-    name: zookeeper-0.2.0
+    name: zookeeper-0.3.0
     namespace: default
     kind: OperatorVersion
   name: "zk"


### PR DESCRIPTION
Zookeeper and Kafka versions have been bumped. Upgrade tests have been updated to reflect this.