### PR TITLE
kafka: add kudo instance label to sts pods

### DIFF
--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: kafka
         kafka: {{ .OperatorName }}
+        kudo.dev/instance: {{ .Name }}
     spec:
       terminationGracePeriodSeconds: 300
       serviceAccountName: {{ .Name }}


### PR DESCRIPTION
we need this label for external service monitors to discover KUDO Kafka sts pods 

Signed-off-by: Zain Malik <zmalikshxil@gmail.com>