### PR TITLE
Fix Flink demo for 0.10

### DIFF
--- a/repository/flink/docs/demo/financial-fraud/demo-operator/operator.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/operator.yaml
@@ -1,5 +1,5 @@
 name: "flink-demo"
-operatorVersion: "0.1.3"
+operatorVersion: "0.1.4"
 kudoVersion: 0.10.0
 kubernetesVersion: 1.15.0
 maintainers:

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/actor.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/actor.yaml
@@ -4,6 +4,9 @@ metadata:
   name: actor
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      actor: {{ .Name }}
   template:
     metadata:
       name: flink-demo-actor

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/flink.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/flink.yaml
@@ -8,7 +8,7 @@ metadata:
   name: flink
 spec:
   operatorVersion:
-    name: flink-0.1.2
+    name: flink-0.2.1
     namespace: default
     type: OperatorVersions
   parameters:

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/generator.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/generator.yaml
@@ -4,6 +4,9 @@ metadata:
   name: generator
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      generator: {{ .Name }}
   template:
     metadata:
       name: flink-demo-generator

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/kafka.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/kafka.yaml
@@ -7,7 +7,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-0.1.3
+    name: kafka-1.2.0
     namespace: default
     type: OperatorVersions
   parameters:

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/templates/zookeeper.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/templates/zookeeper.yaml
@@ -7,7 +7,7 @@ metadata:
   name: zk
 spec:
   operatorVersion:
-    name: zookeeper-0.2.0
+    name: zookeeper-0.3.0
     namespace: default
     type: OperatorVersions
   # Add fields here

--- a/repository/flink/operator/operator.yaml
+++ b/repository/flink/operator/operator.yaml
@@ -1,6 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 name: "flink"
-operatorVersion: "0.2.0"
+operatorVersion: "0.2.1"
 kudoVersion: 0.10.0
 kubernetesVersion: 1.15.0
 appVersion: 1.7.2

--- a/repository/flink/operator/templates/taskmanager-deployment.yaml
+++ b/repository/flink/operator/templates/taskmanager-deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Namespace }}
 spec:
   replicas: {{ .Params.flink_taskmanager_replicas }}
+  selector:
+    matchLabels:
+      app: flink
+      component: {{ .Name }}-taskmanager
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fixes #172 

* change operator versions to the latest
* add selector: to Deployment object as required by the v1 API
* clean up formatting in the demo README