### PR TITLE
Fix typo

### DIFF
--- a/repository/flink/operator/templates/taskmanager-deployment.yaml
+++ b/repository/flink/operator/templates/taskmanager-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - "-Dtaskmanager.data.port=6121"
             - "-Dquery.server.port=6125"
             - "-Dblob.server.port=6124"
-            - "-Dlog.file=/logs/jobmanager.log"
+            - "-Dlog.file=/logs/taskmanager.log"
           ports:
             - containerPort: 6121
               name: data


### PR DESCRIPTION
taskmanager's log should be write to /logs/taskmanager.log