### PR TITLE
kafka: introduce plans and fix node-exporter

### DIFF
--- a/repository/kafka/README.md
+++ b/repository/kafka/README.md
@@ -20,8 +20,8 @@ To get more information around KUDO Kafka architecture please take a look on the
 
 ## Getting started
 
-The latest stable version of Kafka operator is `1.1.0`
-For more details, please see the [v1.1 docs](./docs/v1.1) folder.
+The latest stable version of Kafka operator is `1.2.1`
+For more details, please see the [v1.1 docs](./docs/v1.2) folder.
 
 
 ## Version Chart
@@ -31,6 +31,8 @@ For more details, please see the [v1.1 docs](./docs/v1.1) folder.
 | 1.0.0      | 2.3.0        | 0.8.0                |
 | 1.0.1      | 2.3.1        | 0.8.0                |
 | 1.0.2      | 2.3.1        | 0.8.0                |
-| **1.1.0**  | **2.4.0**    | **0.9.0**            |
-| latest     | 2.4.0        | 0.9.0                |
+| 1.1.0      | 2.4.0        | 0.9.0                |
+| 1.2.0      | 2.4.0        | 0.10.0               |
+| **1.2.1**  | **2.4.0**    | **0.10.0**           |
+| latest     | 2.4.0        | 0.10.0               |
 

--- a/repository/kafka/docs/latest/configuration.md
+++ b/repository/kafka/docs/latest/configuration.md
@@ -75,7 +75,7 @@ You can install the KUDO Zookeeper or you can use any other Zookeeper cluster yo
 You can configure KUDO Kafka to use Zookeeper using the parameter `ZOOKEEPER_URI`
 Let's see this with an example:
 ```
-$ kubectl kudo install kafka --instance=my-kafka-cluster \
+$ kubectl kudo install kafka --instance=my-kafka-name \
   -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
 ```
 In the above example KUDO Kafka cluster will connect to the Zookeeper cluster available via following DNS names `zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181`
@@ -87,7 +87,7 @@ To avoid this to happen, KUDO Kafka persists its cluster topology in zk node wit
 
 Let's for example see what will the zk path look like in the above example where we just configured `ZOOKEEPER_URI`:
 ```
-$ kubectl kudo install kafka --instance=my-kafka-cluster \
+$ kubectl kudo install kafka --instance=my-kafka-name \
   -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
 ```
 

--- a/repository/kafka/docs/latest/configuration.md
+++ b/repository/kafka/docs/latest/configuration.md
@@ -8,7 +8,7 @@ But users can and should tune the configurations based on the workload requireme
 ##### Tuning the resources for the Kafka Cluster
 
 ```
-kubectl kudo install kafka --instance=my-kafka-name \
+$ kubectl kudo install kafka --instance=my-kafka-name \
             -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
             -p ZOOKEEPER_PATH=/custom-path \
             -p BROKER_CPUS=3000m \
@@ -29,16 +29,16 @@ For using a more robust health check based on broker functionality you can set t
 This check is a producer-consumer check based on a custom heartbeat topic which you can set using the parameter `LIVENESS_TOPIC_PREFIX`.
 
 ```
-kubectl kudo install kafka --instance=my-kafka-name -p LIVENESS_METHOD=FUNCTIONAL -p LIVENESS_TOPIC_PREFIX=MyHealthCheckTopic
+$ kubectl kudo install kafka --instance=my-kafka-name -p LIVENESS_METHOD=FUNCTIONAL -p LIVENESS_TOPIC_PREFIX=MyHealthCheckTopic
 ```
 ###### Using Kerberos with health checks
 
 Health checks can be enabled when using [Kerberos with KUDO Kafka](security.md). 
 When using `FUNCTIONAL` method then additional principals needs to be  created. Assuming `livenessProbe` as the principal name the principals will be: 
 ```
-livenessProbe/kafka-kafka-0.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
-livenessProbe/kafka-kafka-1.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
-livenessProbe/kafka-kafka-2.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+livenessProbe/my-kafka-name-kafka-0.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+livenessProbe/my-kafka-name-kafka-1.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+livenessProbe/my-kafka-name-kafka-2.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
 ```
 You need to create one principal per broker for each individual livenessProbe.
 
@@ -49,13 +49,13 @@ By default, the Kafka operator will use the default storage class of the Kuberne
 To deploy Kafka using a different storage class, you can use the parameter `STORAGE_CLASS`
 
 ```
-kubectl kudo install kafka --instance=my-kafka-name -p STORAGE_CLASS=<STORAGE_CLASS_NAME>
+$ kubectl kudo install kafka --instance=my-kafka-name -p STORAGE_CLASS=<STORAGE_CLASS_NAME>
 ```
 
 ##### Deploying an ephemeral Kafka cluster without persistence
 
 ```
-kubectl kudo install kafka --instance=my-kafka-name -p PERSISTENT_STORAGE=false
+$ kubectl kudo install kafka --instance=my-kafka-name -p PERSISTENT_STORAGE=false
 ```
 
 Having `PERSISTENT_STORAGE` value `false` means that any data or logs inside the brokers will be lost after a pod restart or rescheduling.
@@ -75,7 +75,7 @@ You can install the KUDO Zookeeper or you can use any other Zookeeper cluster yo
 You can configure KUDO Kafka to use Zookeeper using the parameter `ZOOKEEPER_URI`
 Let's see this with an example:
 ```
-kubectl kudo install kafka --instance=my-kafka-cluster \
+$ kubectl kudo install kafka --instance=my-kafka-cluster \
   -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
 ```
 In the above example KUDO Kafka cluster will connect to the Zookeeper cluster available via following DNS names `zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181`
@@ -87,7 +87,7 @@ To avoid this to happen, KUDO Kafka persists its cluster topology in zk node wit
 
 Let's for example see what will the zk path look like in the above example where we just configured `ZOOKEEPER_URI`:
 ```
-kubectl kudo install kafka --instance=my-kafka-cluster \
+$ kubectl kudo install kafka --instance=my-kafka-cluster \
   -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
 ```
 
@@ -99,7 +99,7 @@ will create a Zookeeper node in path `/my-kafka-cluster`.
 You can also decide to chose a custom Zookeeper node path, using the KUDO Kafka parameter `ZOOKEEPER_PATH`
 Let's see this with an example:
 ```
-kubectl kudo install kafka --instance=my-kafka-name \
+$ kubectl kudo install kafka --instance=my-kafka-name \
   -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
   -p ZOOKEEPER_PATH=/custom-path
 ```

--- a/repository/kafka/docs/latest/custom.md
+++ b/repository/kafka/docs/latest/custom.md
@@ -28,14 +28,14 @@ data:
 Create the ConfigMap in the namespace we will have the KUDO Kafka cluster
 
 ```
-> kubectl create -f custom-configuration.yaml -n kudo-kafka
+$ kubectl create -f custom-configuration.yaml -n kudo-kafka
 configmap/custom-configuration created
 ```
 
 Verify the ConfigMap is created correctly 
 
 ```
-> kubectl get configmap custom-configuration -n kudo-kafka -o yaml
+$ kubectl get configmap custom-configuration -n kudo-kafka -o yaml
 apiVersion: v1
 data:
   server.properties: |
@@ -54,7 +54,7 @@ metadata:
 Now we are ready to start the KUDO Kafka cluster with custom configuration to be used with default tuned configuration. 
 
 ```
-kubectl kudo install kafka \
+$ kubectl kudo install kafka \
     --instance=kafka --namespace=kudo-kafka \
     -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
     -p BROKER_COUNT=3 \
@@ -64,7 +64,7 @@ kubectl kudo install kafka \
 Verify in the logs if the custom configuration is being used in the Apache Kafka brokers and the `KafkaConfig` is correctly using `connection.failed.authentication.delay.ms` with value of `300` 
 
 ```
-> kubectl logs kafka-kafka-0 -n kudo-kafka
+$ kubectl logs kafka-kafka-0 -n kudo-kafka
 [2019-10-21 13:46:58,325] Appending custom configuration file to the server.properties...
 ssl.secure.random.implementation=SHA1PRNG
 connection.failed.authentication.delay.ms=300
@@ -83,14 +83,14 @@ The KUDO Kafka custom configuration ConfigMap isn't watched by the KUDO controll
 Edit the configmap with changes we want to rollout:
 
 ```
-> kubectl edit configmap custom-configuration -n kudo-kafka
+$ kubectl edit configmap custom-configuration -n kudo-kafka
 configmap/custom-configuration edited
 ```
 
 Perform a rolling restart on the statefulset to reload the configmap.
 
 ```
-> kubectl rollout restart statefulset kafka-kafka -n kudo-kafka
+$ kubectl rollout restart statefulset kafka-kafka -n kudo-kafka
 statefulset.apps/kafka-kafka restarted
 ```
 
@@ -133,14 +133,14 @@ To have KUDO Kafka detect correctly the custom metrics reporter configuration `d
 Create the ConfigMap in the namespace we will have the KUDO Kafka cluster
 
 ```
-> kubectl create -f metrics-configuration.yaml -n kudo-kafka
+$ kubectl create -f metrics-configuration.yaml -n kudo-kafka
 configmap/metrics-config created
 ```
 
 Verify the ConfigMap is created correctly 
 
 ```
-> kubectl get configmap metrics-config -n kudo-kafka -o yaml
+$ kubectl get configmap metrics-config -n kudo-kafka -o yaml
 apiVersion: v1
 data:
   metrics.properties: |
@@ -166,7 +166,7 @@ metadata:
 Now we are ready to start the KUDO Kafka cluster with custom metrics reporter configuration
 
 ```
-> kubectl kudo install kafka \
+$ kubectl kudo install kafka \
     --instance=kafka --namespace=kudo-kafka \
     -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
     -p BROKER_COUNT=3 \
@@ -176,7 +176,7 @@ Now we are ready to start the KUDO Kafka cluster with custom metrics reporter co
 Verify that brokers have the correct metrics reporter configuration
 
 ```
-> kubectl exec -ti kafka-kafka-0 cat /metrics/metrics.properties
+$ kubectl exec -ti kafka-kafka-0 cat /metrics/metrics.properties
 rules:
     # Special cases and very specific rules
     - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
@@ -195,13 +195,13 @@ Like the custom configuration the custom metrics reporter is also not watched by
 Edit the configmap with changes we want to rollout:
 
 ```
-> kubectl edit configmap metrics-config -n kudo-kafka
+$ kubectl edit configmap metrics-config -n kudo-kafka
 configmap/metrics-config edited
 ```
 
 Perform a rolling restart on the statefulset to reload the configmap.
 
 ```
-> kubectl rollout restart statefulset kafka-kafka -n kudo-kafka
+$ kubectl rollout restart statefulset kafka-kafka -n kudo-kafka
 statefulset.apps/kafka-kafka restarted
 ```

--- a/repository/kafka/docs/latest/external-access.md
+++ b/repository/kafka/docs/latest/external-access.md
@@ -36,7 +36,7 @@ The parameter used to configure the external loadbalancers is `EXTERNAL_ADVERTIS
 When set to `LoadBalancer` it creates one service per broker to expose each broker externally. 
 
 ```
-kubectl kudo install kafka --instance=kafka \
+$ kubectl kudo install kafka --instance=kafka \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=LoadBalancer
 ```
@@ -46,7 +46,7 @@ kubectl kudo install kafka --instance=kafka \
 For these Kubernetes Services, KUDO Kafka uses the `externalTrafficPolicy:local` to avoid any second hop. As each broker gets its own loadbalancer we can avoid the extra hops and get a better network performance.
 
 ```
-kubectl get svc
+$ kubectl get svc
 NAME                     TYPE           CLUSTER-IP    EXTERNAL-IP                                                               PORT(S)                      AGE
 kafka-kafka-0-external   LoadBalancer   10.0.13.34    aebb0d2f2adda4b22b7d9b0c07a865b8-1700665253.us-west-2.elb.amazonaws.com   9097:31713/TCP               11s
 kafka-kafka-1-external   LoadBalancer   10.0.45.151   a8ae206a726b24fed91b82eb9110e0d1-1872607345.us-west-2.elb.amazonaws.com   9097:30786/TCP               11s
@@ -58,7 +58,7 @@ Producers and consumers can connect to `aebb0d2f2adda4b22b7d9b0c07a865b8-1700665
 To verify if the `server.properties` has the correct configuration for the `listeners`,`advertised.listeners` and `listener.security.protocol.map`, users can check the `server.properties` content in the broker pods. For example for broker `2` you just need to run the following command:
 
 ```
-> kubectl exec -ti kafka-kafka-2 -c k8skafka cat server.properties
+$ kubectl exec -ti kafka-kafka-2 -c k8skafka cat server.properties
 [ ... lines removed for clarity ...]
 listeners=INTERNAL://0.0.0.0:9095,EXTERNAL_INGRESS://0.0.0.0:9097
 advertised.listeners=INTERNAL://kafka-kafka-2.kafka-svc.default.svc.cluster.local:9095,EXTERNAL_INGRESS://a252e64a36f4443ecbea2fa4c4bf8441-1574422153.us-west-2.elb.amazonaws.com:9097
@@ -78,7 +78,7 @@ KUDO Kafka supports enabling and disabling of the parameter `EXTERNAL_ADVERTISED
 To enable the external access via load balancers:
 
 ```
-kubectl kudo update --instance=kafka \
+$ kubectl kudo update --instance=kafka \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=LoadBalancer 
 ```
@@ -86,7 +86,7 @@ kubectl kudo update --instance=kafka \
 To disable the external access via load balancers:
 
 ```
-kubectl kudo update --instance=kafka \
+$ kubectl kudo update --instance=kafka \
 	-p EXTERNAL_ADVERTISED_LISTENER=false
 ```
 

--- a/repository/kafka/docs/latest/external-access.md
+++ b/repository/kafka/docs/latest/external-access.md
@@ -36,7 +36,7 @@ The parameter used to configure the external loadbalancers is `EXTERNAL_ADVERTIS
 When set to `LoadBalancer` it creates one service per broker to expose each broker externally. 
 
 ```
-$ kubectl kudo install kafka --instance=kafka \
+$ kubectl kudo install kafka --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=LoadBalancer
 ```
@@ -78,7 +78,7 @@ KUDO Kafka supports enabling and disabling of the parameter `EXTERNAL_ADVERTISED
 To enable the external access via load balancers:
 
 ```
-$ kubectl kudo update --instance=kafka \
+$ kubectl kudo update --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=LoadBalancer 
 ```
@@ -86,7 +86,7 @@ $ kubectl kudo update --instance=kafka \
 To disable the external access via load balancers:
 
 ```
-$ kubectl kudo update --instance=kafka \
+$ kubectl kudo update --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=false
 ```
 
@@ -99,7 +99,7 @@ The parameter used to configure the external loadbalancers is `EXTERNAL_ADVERTIS
 When set to `NodePort` it creates one service per broker. 
 
 ```
-kubectl kudo install kafka --instance=kafka \
+kubectl kudo install kafka --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=NodePort
 ```
@@ -156,7 +156,7 @@ KUDO Kafka supports enabling and disabling of the parameter `EXTERNAL_ADVERTISED
 To enable the external access via node ports:
 
 ```
-kubectl kudo update --instance=kafka \
+kubectl kudo update --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=NodePort 
 ```
@@ -164,7 +164,7 @@ kubectl kudo update --instance=kafka \
 To disable the external access via load balancers:
 
 ```
-kubectl kudo update --instance=kafka \
+kubectl kudo update --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=false
 ```
 
@@ -177,14 +177,14 @@ Due to known kubernetes issue in [issues/221](https://github.com/kubernetes/kube
 First disable the external access
 
 ```
-kubectl kudo update --instance=kafka \
+kubectl kudo update --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=false
 ```
 
 Once the plan status is complete, we can enable again with `LoadBalancer` type
 
 ````
-kubectl kudo install kafka --instance=kafka \
+kubectl kudo install kafka --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=LoadBalancer
 ````
@@ -194,14 +194,14 @@ kubectl kudo install kafka --instance=kafka \
 First disable the external access
 
 ```
-kubectl kudo update --instance=kafka \
+kubectl kudo update --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=false
 ```
 
 Once the plan status is complete, we can enable again with `NodePort` type
 
 ```
-kubectl kudo install kafka --instance=kafka \
+kubectl kudo install kafka --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=NodePort
 ```
@@ -215,7 +215,7 @@ kubectl kudo install kafka --instance=kafka \
 Exposing KUDO Kafka works with the TLS encryption enabled. 
 
 ```
-kubectl kudo install kafka --instance=kafka \
+kubectl kudo install kafka --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=LoadBalancer \
 	-p CLIENT_PORT_ENABLED=false \
@@ -226,7 +226,7 @@ kubectl kudo install kafka --instance=kafka \
 And we can verify that `EXTERNAL_INGRESS` is using `SSL` protocol.
 
 ```
-> kubectl exec -ti kafka-kafka-2 -c k8skafka cat server.properties
+> kubectl exec -ti kafka-instance-kafka-2 -c k8skafka cat server.properties
 [ ... lines removed for clarity ...]
 listeners=INTERNAL://0.0.0.0:9095,EXTERNAL_INGRESS://0.0.0.0:9097
 advertised.listeners=INTERNAL://kafka-kafka-2.kafka-svc.default.svc.cluster.local:9095,EXTERNAL_INGRESS://a252e64a36f4443ecbea2fa4c4bf8441-1574422153.us-west-2.elb.amazonaws.com:9097
@@ -240,7 +240,7 @@ inter.broker.listener.name=INTERNAL
 Exposing KUDO Kafka works with the TLS encryption enabled. 
 
 ```
-kubectl kudo install kafka --instance=kafka \
+kubectl kudo install kafka --instance=kafka-instance \
 	-p EXTERNAL_ADVERTISED_LISTENER=true \
 	-p EXTERNAL_ADVERTISED_LISTENER_TYPE=NodePort \
 	-p CLIENT_PORT_ENABLED=false \
@@ -251,7 +251,7 @@ kubectl kudo install kafka --instance=kafka \
 And we can verify that `EXTERNAL_INGRESS` is using `SSL` protocol.
 
 ```
-> kubectl exec -ti kafka-kafka-2 -c k8skafka cat server.properties
+> kubectl exec -ti kafka-instance-kafka-2 -c k8skafka cat server.properties
 [ ... lines removed for clarity ...]
 listeners=INTERNAL://0.0.0.0:9095,EXTERNAL_INGRESS://0.0.0.0:9097
 advertised.listeners=INTERNAL://kafka-kafka-2.kafka-svc.default.svc.cluster.local:9095,EXTERNAL_INGRESS://34.214.27.71:30904

--- a/repository/kafka/docs/latest/install.md
+++ b/repository/kafka/docs/latest/install.md
@@ -25,17 +25,28 @@ kubectl kudo install kafka
 
 Verify the if the deploy plan for `--instance=kafka-instance` is complete.
 ```
-kubectl kudo plan status --instance=kafka-instance
+$ kubectl kudo plan status --instance=kafka-instance
 Plan(s) for "kafka-instance" in namespace "default":
 .
-└── kafka-instance (Operator-Version: "kafka-1.0.0" Active-Plan: "deploy")
+└── kafka-instance (Operator-Version: "kafka-1.2.1" Active-Plan: "deploy")
     ├── Plan deploy (serial strategy) [COMPLETE]
-    │  └── Phase deploy-kafka [COMPLETE]
-    │    └── Step deploy (COMPLETE)
-    └── Plan not-allowed (serial strategy) [NOT ACTIVE]
-        └── Phase not-allowed (serial strategy) [NOT ACTIVE]
-            └── Step not-allowed (serial strategy) [NOT ACTIVE]
-                └── not-allowed [NOT ACTIVE]
+    │   └── Phase deploy-kafka (serial strategy) [COMPLETE]
+    │       ├── Step configuration [COMPLETE]
+    │       ├── Step service [COMPLETE]
+    │       ├── Step app [COMPLETE]
+    │       └── Step addons [COMPLETE]
+    ├── Plan external-access (serial strategy) [NOT ACTIVE]
+    │   └── Phase external-access-resources (serial strategy) [NOT ACTIVE]
+    │       └── Step external [NOT ACTIVE]
+    ├── Plan mirrormaker (serial strategy) [NOT ACTIVE]
+    │   └── Phase deploy-mirror-maker (serial strategy) [NOT ACTIVE]
+    │       └── Step deploy [NOT ACTIVE]
+    ├── Plan not-allowed (serial strategy) [NOT ACTIVE]
+    │   └── Phase not-allowed (serial strategy) [NOT ACTIVE]
+    │       └── Step not-allowed [NOT ACTIVE]
+    └── Plan service-monitor (serial strategy) [NOT ACTIVE]
+        └── Phase enable-service-monitor (serial strategy) [NOT ACTIVE]
+            └── Step add-service-monitor [NOT ACTIVE]
 ```
 
 You can view all configuration options [here](./configuration.md)

--- a/repository/kafka/docs/latest/kudo-kafka-runbook.md
+++ b/repository/kafka/docs/latest/kudo-kafka-runbook.md
@@ -15,7 +15,7 @@ To isolate our operators from other running installations over the cluster, we p
 
 Let us create a namespace `kudo-kafka` using:
 ```
-kubectl create ns kudo-kafka
+$ kubectl create ns kudo-kafka
 ```
 Sample output of this command:
         `namespace/kudo-kafka created`
@@ -24,13 +24,13 @@ Sample output of this command:
 
 KUDO Kafka should be backed by KUDO Zookeeper running in the background. To install KUDO Zookeeper in the namespace `kudo-kafka`:
 ```
-kubectl kudo install zookeeper --instance=zk --namespace=kudo-kafka
+$ kubectl kudo install zookeeper --instance=zk --namespace=kudo-kafka
 ```
 
 Sample output of this command:
 ```
 operator.kudo.dev/v1beta1/zookeeper created
-operatorversion.kudo.dev/v1beta1/zookeeper-0.2.0 created
+operatorversion.kudo.dev/v1beta1/zookeeper-0.3.0 created
 instance.kudo.dev/v1beta1/zk created
 ```
 
@@ -39,7 +39,7 @@ You can check for the successful deployment of Zookeeper service through:
 $ kubectl kudo plan status --instance=zk --namespace=kudo-kafka
 Plan(s) for "zk" in namespace "kudo-kafka":
 .
-└── zk (Operator-Version: "zookeeper-0.2.0" Active-Plan: "deploy")
+└── zk (Operator-Version: "zookeeper-0.3.0" Active-Plan: "deploy")
     ├── Plan deploy (serial strategy) [COMPLETE]
     │   ├── Phase zookeeper [COMPLETE]
     │   │   └── Step deploy (COMPLETE)
@@ -63,7 +63,7 @@ KUDO Kafka can be deployed with some dummy user workload running over Kafka brok
 
 In order to install KUDO Kafka having user workload in the namespace `kudo-kafka`:
 ```
-kubectl kudo install kafka --instance=kafka --namespace=kudo-kafka \
+$ kubectl kudo install kafka --instance=kafka --namespace=kudo-kafka \
  -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
  -p RUN_USER_WORKLOAD=true \
  -p ADD_SERVICE_MONITOR=true
@@ -78,7 +78,7 @@ kubectl kudo install kafka --instance=kafka --namespace=kudo-kafka \
 Sample output of this command:
 ```
 operator.kudo.dev/v1beta1/kafka created
-operatorversion.kudo.dev/v1beta1/kafka-1.0.1 created
+operatorversion.kudo.dev/v1beta1/kafka-1.2.1 created
 instance.kudo.dev/v1beta1/kafka created
 ```
 
@@ -99,9 +99,9 @@ zk-zookeeper-2                                  1/1     Running   0          128
 
 To wrap up, here is a summary of commands that should be executed in order to get the KUDO Kafka service up and running, with some dummy user workload present over it:
 ```
-kubectl create ns kudo-kafka
-kubectl kudo install zookeeper --instance=zk --namespace=kudo-kafka
-kubectl kudo install kafka --instance=kafka --namespace=kudo-kafka \
+$ kubectl create ns kudo-kafka
+$ kubectl kudo install zookeeper --instance=zk --namespace=kudo-kafka
+$ kubectl kudo install kafka --instance=kafka --namespace=kudo-kafka \
  -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
  -p RUN_USER_WORKLOAD=true \
  -p ADD_SERVICE_MONITOR=true

--- a/repository/kafka/docs/latest/monitoring.md
+++ b/repository/kafka/docs/latest/monitoring.md
@@ -13,7 +13,7 @@ When the Kafka operator is deployed with the parameter `METRICS_ENABLED=true` (w
 
 
 ```
-kubectl describe svc kafka-svc
+$ kubectl describe svc kafka-svc
 ...
 Port:              metrics  9094/TCP
 TargetPort:        9094/TCP
@@ -28,11 +28,11 @@ To use the prometheus service monitor, it's necessary to have installed the [pro
 
 Users can monitor the Kafka cluster using independent service monitor. Or use the one that comes with KUDO Kafka
 
-`kubectl kudo install kafka --instance=kafka -p ADD_SERVICE_MONITOR=true`
+`$ kubectl kudo install kafka --instance=kafka -p ADD_SERVICE_MONITOR=true`
 
 Or users can provide their own service-monitor. If Kafka is using the default namespace, we can create a [service-monitor](./resources/service-monitor.yaml) with the following:
 ```
-kubectl create -f resources/service-monitor.yaml
+$ kubectl create -f resources/service-monitor.yaml
 ```
 
 Upload this [grafana json](./resources/grafana-dashboard.json) and you should see the following Kafka dashboard:
@@ -42,5 +42,5 @@ Upload this [grafana json](./resources/grafana-dashboard.json) and you should se
 ### Disable the metrics
 
  ```
-kubectl kudo install kafka --instance=kafka --parameter METRICS_ENABLED=false
+$ kubectl kudo install kafka --instance=kafka --parameter METRICS_ENABLED=false
  ```

--- a/repository/kafka/docs/latest/monitoring.md
+++ b/repository/kafka/docs/latest/monitoring.md
@@ -28,7 +28,7 @@ To use the prometheus service monitor, it's necessary to have installed the [pro
 
 Users can monitor the Kafka cluster using independent service monitor. Or use the one that comes with KUDO Kafka
 
-`$ kubectl kudo install kafka --instance=kafka -p ADD_SERVICE_MONITOR=true`
+`$ kubectl kudo install kafka --instance=kafka-instance -p ADD_SERVICE_MONITOR=true`
 
 Or users can provide their own service-monitor. If Kafka is using the default namespace, we can create a [service-monitor](./resources/service-monitor.yaml) with the following:
 ```
@@ -42,5 +42,5 @@ Upload this [grafana json](./resources/grafana-dashboard.json) and you should se
 ### Disable the metrics
 
  ```
-$ kubectl kudo install kafka --instance=kafka --parameter METRICS_ENABLED=false
+$ kubectl kudo install kafka --instance=kafka-instance --parameter METRICS_ENABLED=false
  ```

--- a/repository/kafka/docs/latest/production.md
+++ b/repository/kafka/docs/latest/production.md
@@ -153,7 +153,7 @@ BACKGROUND_THREADS=10
 
 ```
 $ kubectl kudo install kafka \
-    --instance=kafka --namespace=kudo-kafka -p ZOOKEEPER_URI=$ZOOKEEPER_URI \
+    --instance=kafka-instance --namespace=kudo-kafka -p ZOOKEEPER_URI=$ZOOKEEPER_URI \
     -p BROKER_CPUS=2000m \
     -p BROKER_COUNT=5 \
     -p BROKER_MEM=4096m \

--- a/repository/kafka/docs/latest/production.md
+++ b/repository/kafka/docs/latest/production.md
@@ -17,7 +17,7 @@ This document optimizes for **data durability over performance**.
 Verify if there is a storage class installed in the Kubernetes cluster. In this example we will use the `aws-ebs-csi-driver` as the storage class reference.
 
 ```
-> kubectl get sc
+$ kubectl get sc
 NAME                             PROVISIONER       AGE
 awsebscsiprovisioner (default)   ebs.csi.aws.com   2d
 ```
@@ -27,7 +27,7 @@ awsebscsiprovisioner (default)   ebs.csi.aws.com   2d
 Verify if the storage class has the option `AllowVolumeExpansion` and is set to `true`.
 
 ```
-> kubectl describe sc awsebscsiprovisioner
+$ kubectl describe sc awsebscsiprovisioner
 Name:                  awsebscsiprovisioner
 IsDefaultClass:        Yes
 Annotations:           kubernetes.io/description=AWS EBS CSI provisioner StorageClass,storageclass.kubernetes.io/is-default-class=true
@@ -57,7 +57,7 @@ If the `StorageClass` is to be shared between many users, a common practice is t
 Let's see an example of a 3-broker KUDO Kafka cluster's `PersistentVolumes` where the `StorageClass` default `ReclaimPolicy` is `Delete` 
 
 ```
-> kubectl get pv
+$ kubectl get pv
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                              STORAGECLASS           REASON   AGE
 pvc-6a9e69f4-b807-440f-b190-357c109e8ad9   5Gi        RWO            Delete           Bound    default/kafka-datadir-kafka-kafka-0                                awsebscsiprovisioner            18h
 pvc-8602a698-14a0-4c3d-85e6-67eb6da80a5d   5Gi        RWO            Delete           Bound    default/kafka-datadir-kafka-kafka-2                                awsebscsiprovisioner            18h
@@ -67,9 +67,9 @@ pvc-de527673-8bee-4e38-9e6d-399ec07c2728   5Gi        RWO            Delete     
 We can patch the `PersistentVolumes` to use the `ReclaimPolicy` of `Retain`
 
 ```
-kubectl patch pv pvc-6a9e69f4-b807-440f-b190-357c109e8ad9 -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
-kubectl patch pv pvc-8602a698-14a0-4c3d-85e6-67eb6da80a5d -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
-kubectl patch pv pvc-de527673-8bee-4e38-9e6d-399ec07c2728 -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+$ kubectl patch pv pvc-6a9e69f4-b807-440f-b190-357c109e8ad9 -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+$ kubectl patch pv pvc-8602a698-14a0-4c3d-85e6-67eb6da80a5d -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+$ kubectl patch pv pvc-de527673-8bee-4e38-9e6d-399ec07c2728 -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 
 persistentvolume/pvc-6a9e69f4-b807-440f-b190-357c109e8ad9 patched
 persistentvolume/pvc-8602a698-14a0-4c3d-85e6-67eb6da80a5d patched
@@ -79,7 +79,7 @@ persistentvolume/pvc-de527673-8bee-4e38-9e6d-399ec07c2728 patched
 Verify the `PersistentVolumes` `ReclaimPolicy` has been changed for all brokers:
 
 ```
-> kubectl get pv
+$ kubectl get pv
 pvc-6a9e69f4-b807-440f-b190-357c109e8ad9   5Gi        RWO            Retain           Bound    default/kafka-datadir-kafka-kafka-0                                awsebscsiprovisioner            18h
 pvc-8602a698-14a0-4c3d-85e6-67eb6da80a5d   5Gi        RWO            Retain           Bound    default/kafka-datadir-kafka-kafka-2                                awsebscsiprovisioner            18h
 pvc-de527673-8bee-4e38-9e6d-399ec07c2728   5Gi        RWO            Retain           Bound    default/kafka-datadir-kafka-kafka-1                                awsebscsiprovisioner            18h
@@ -152,7 +152,7 @@ BACKGROUND_THREADS=10
 ### Run the KUDO Kafka with tuned parameters
 
 ```
-kubectl kudo install kafka \
+$ kubectl kudo install kafka \
     --instance=kafka --namespace=kudo-kafka -p ZOOKEEPER_URI=$ZOOKEEPER_URI \
     -p BROKER_CPUS=2000m \
     -p BROKER_COUNT=5 \

--- a/repository/kafka/docs/latest/release-notes.md
+++ b/repository/kafka/docs/latest/release-notes.md
@@ -2,6 +2,15 @@
 
 ## latest
 
+## v1.2.1
+
+- Remove unused collectors from node exporter sidecar
+- Introduce new plans to fix the errors when re-running a plan
+
+## v1.2.0
+
+- Updated operator.yaml to adopt to KUDO `0.10.0`
+
 ## v1.1.0
 
 - Apache Kafka upgraded to 2.4.0

--- a/repository/kafka/docs/latest/security.md
+++ b/repository/kafka/docs/latest/security.md
@@ -11,20 +11,20 @@ By default, KUDO Kafka brokers use the plaintext protocol for its inter-broker c
 Create the TLS certificate to be used for Kafka TLS encryptions
 
 ```
-openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout tls.key -out tls.crt -subj "/CN=Kafka" -days 365
+$ openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout tls.key -out tls.crt -subj "/CN=Kafka" -days 365
 ```
 
 Create a kubernetes TLS secret using the certificate created in previous step 
 
 ```
-kubectl create secret tls kafka-tls -n kudo-kafka --cert=tls.crt --key=tls.key
+$ kubectl create secret tls kafka-tls -n kudo-kafka --cert=tls.crt --key=tls.key
 ```
 
 :warning: Make sure to create the certificate in the same namespace where the KUDO Kafka is being installed.
 
 ```
-kubectl kudo install kafka \
-    --instance=kafka --namespace=kudo-kafka \
+$ kubectl kudo install kafka \
+    --instance=kafka-instance --namespace=kudo-kafka \
     -p TRANSPORT_ENCRYPTION_ENABLED=true \
     -p TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT=false \
     -p SSL_AUTHENTICATION_ENABLED=false \
@@ -44,8 +44,8 @@ Follow the steps of creating the TLS secret for the [TLS encryption](#enabling-t
 And enable the TLS encryption and also set the parameter `SSL_AUTHENTICATION_ENABLED` to `true`
 
 ```
-kubectl kudo install kafka \
-  --instance=kafka --namespace=kudo-kafka \
+$ kubectl kudo install kafka \
+  --instance=kafka-instance --namespace=kudo-kafka \
     -p AUTHORIZATION_ENABLED=true \
     -p AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND=false \
     -p AUTHORIZATION_SUPER_USERS="User:User1" \
@@ -73,7 +73,7 @@ Kerberos authentication relies on a central authority to verify that Kafka clien
 
 The KUDO Kafka service requires a Kerberos principal for each broker to be deployed. Each principal must be of the form
 ```
-<service primary>/kafka-kafka-<broker index>.kafka-svc.<namespace>.svc.cluster.local@<service realm>
+<service primary>/kafka-instance-kafka-<broker index>.kafka-svc.<namespace>.svc.cluster.local@<service realm>
 ```
 with:
 * ```service primary = KERBEROS_PRIMARY```
@@ -83,8 +83,8 @@ with:
 
 For example, if installing with these options:
 ```
-kubectl kudo install kafka \
-  --instance=kafka --namespace=kudo-kafka \
+$ kubectl kudo install kafka \
+  --instance=kafka-instance --namespace=kudo-kafka \
     -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
     -p KERBEROS_ENABLED=true \
     -p KERBEROS_DEBUG=false\
@@ -97,9 +97,9 @@ kubectl kudo install kafka \
 ```
 then the principals to create would be:
 ```
-kafka/kafka-kafka-0.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
-kafka/kafka-kafka-1.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
-kafka/kafka-kafka-2.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+kafka/kafka-instance-kafka-0.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+kafka/kafka-instance-kafka-1.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+kafka/kafka-instance-kafka-2.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
 ```
 
 Use `KERBEROS_USE_TCP=true` parameter to use `TCP` protocol for KDC. By default it will try to use UDP. 
@@ -127,8 +127,8 @@ The KUDO Kafka service supports Kafka’s ACL-based authorization system.  To us
 Install the KUDO Kafka service with the following options in addition to your own (remember, Kerberos must be enabled):
 
 ```
-kubectl kudo install kafka \
-  --instance=kafka --namespace=kudo-kafka \
+$ kubectl kudo install kafka \
+  --instance=kafka-instance --namespace=kudo-kafka \
     -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
     -p BROKER_COUNT=3 \
     -p KERBEROS_ENABLED=true \
@@ -148,8 +148,8 @@ The format of the list is `User:user1;User:user2;....` Using Kerberos authentica
 Install the KUDO Kafka service with the following options in addition to your own (remember, TLS authentication must be enabled):
 
 ```
-kubectl kudo install kafka \
-  --instance=kafka --namespace=kudo-kafka \
+$ kubectl kudo install kafka \
+  --instance=kafka-instance --namespace=kudo-kafka \
     -p ZOOKEEPER_URI=zk-zookeeper-0.zk-hs:2181,zk-zookeeper-1.zk-hs:2181,zk-zookeeper-2.zk-hs:2181 \
     -p BROKER_CPUS=200m \
     -p BROKER_COUNT=3 \
@@ -162,7 +162,5 @@ kubectl kudo install kafka \
     -p TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT=false \
     -p SSL_AUTHENTICATION_ENABLED=true
 ```
-
-
 
 NOTE: It is possible to enable Authorization after initial installation but the service may become unavailable during the transition. Additionally, Kafka clients may fail to function if they do not have the correct ACLs assigned to their principals. During the transition `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` can be set to `true` to prevent clients from failing until their ACLs can be set correctly. After the transition, `AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND` should be reset back to `false`.

--- a/repository/kafka/docs/latest/update.md
+++ b/repository/kafka/docs/latest/update.md
@@ -18,13 +18,13 @@ There are a few constraints related to storage. These constraints are documented
 Enable the `delete.topic.enable`
 
 ```
-> kubectl kudo update kafka -p DELETE_TOPIC_ENABLE=true 
+$ kubectl kudo update kafka -p DELETE_TOPIC_ENABLE=true 
 ```
 
 Enable the `auto.create.topics.enable`
 
 ```
-> kubectl kudo update kafka -p  AUTO_CREATE_TOPICS_ENABLE=true
+$ kubectl kudo update kafka -p  AUTO_CREATE_TOPICS_ENABLE=true
 ```
 
 ## Scaling the brokers
@@ -38,43 +38,73 @@ It is recommended that users closely monitor and control broker scaling due to t
 To scale horizontally, we can increase the broker count. Lets update the broker count from default `3` to `5`
 
 ```
-> kubectl kudo update kafka -p BROKER_COUNT=4
+$ kubectl kudo update kafka -p BROKER_COUNT=4
 ```
 
 Check the plan status:
 
 ```
-> kubectl kudo plan status --instance=kafka
-Plan(s) for "kafka" in namespace "default":
+$ kubectl kudo plan status --instance=kafka-instance
+Plan(s) for "kafka-instance" in namespace "default":
 .
-└── kafka (Operator-Version: "kafka-0.2.0" Active-Plan: "kafka-deploy-351387000")
-    └── Plan deploy (serial strategy) [IN_PROGRESS]
-        └── Phase deploy-kafka (serial strategy) [IN_PROGRESS]
-            └── Step deploy (IN_PROGRESS)
+└── kafka-instance (Operator-Version: "kafka-1.2.1" Active-Plan: "deploy")
+    ├── Plan deploy (serial strategy) [IN_PROGRESS]
+    │   └── Phase deploy-kafka (serial strategy) [IN_PROGRESS]
+    │       ├── Step configuration [COMPLETE]
+    │       ├── Step service [COMPLETE]
+    │       ├── Step app [IN_PROGRESS]
+    │       └── Step addons [PENDING]
+    ├── Plan external-access (serial strategy) [NOT ACTIVE]
+    │   └── Phase external-access-resources (serial strategy) [NOT ACTIVE]
+    │       └── Step external [NOT ACTIVE]
+    ├── Plan mirrormaker (serial strategy) [NOT ACTIVE]
+    │   └── Phase deploy-mirror-maker (serial strategy) [NOT ACTIVE]
+    │       └── Step deploy [NOT ACTIVE]
+    ├── Plan not-allowed (serial strategy) [NOT ACTIVE]
+    │   └── Phase not-allowed (serial strategy) [NOT ACTIVE]
+    │       └── Step not-allowed [NOT ACTIVE]
+    └── Plan service-monitor (serial strategy) [NOT ACTIVE]
+        └── Phase enable-service-monitor (serial strategy) [NOT ACTIVE]
+            └── Step add-service-monitor [NOT ACTIVE]
 ```
 
 Once the plan status is complete
 
-```kubectl kudo plan status --instance=kafka
-> kubectl kudo plan status --instance=kafka
-Plan(s) for "kafka" in namespace "default":
+```kubectl kudo plan status --instance=kafka-instance
+$ kubectl kudo plan status --instance=kafka-instance
+Plan(s) for "kafka-instance" in namespace "default":
 .
-└── kafka (Operator-Version: "kafka-0.2.0" Active-Plan: "kafka-deploy-351387000")
-    └── Plan deploy (serial strategy) [COMPLETE]
-        └── Phase deploy-kafka (serial strategy) [COMPLETE]
-            └── Step deploy (COMPLETE)
+└── kafka-instance (Operator-Version: "kafka-1.2.1" Active-Plan: "deploy")
+    ├── Plan deploy (serial strategy) [IN_PROGRESS]
+    │   └── Phase deploy-kafka (serial strategy) [COMPLETE]
+    │       ├── Step configuration [COMPLETE]
+    │       ├── Step service [COMPLETE]
+    │       ├── Step app [COMPLETE]
+    │       └── Step addons [COMPLETE]
+    ├── Plan external-access (serial strategy) [NOT ACTIVE]
+    │   └── Phase external-access-resources (serial strategy) [NOT ACTIVE]
+    │       └── Step external [NOT ACTIVE]
+    ├── Plan mirrormaker (serial strategy) [NOT ACTIVE]
+    │   └── Phase deploy-mirror-maker (serial strategy) [NOT ACTIVE]
+    │       └── Step deploy [NOT ACTIVE]
+    ├── Plan not-allowed (serial strategy) [NOT ACTIVE]
+    │   └── Phase not-allowed (serial strategy) [NOT ACTIVE]
+    │       └── Step not-allowed [NOT ACTIVE]
+    └── Plan service-monitor (serial strategy) [NOT ACTIVE]
+        └── Phase enable-service-monitor (serial strategy) [NOT ACTIVE]
+            └── Step add-service-monitor [NOT ACTIVE]
 ```
 
 We can see that we have 5 brokers up and running
 
 ```
-> kubectl get pods -l app=kafka
-NAME            READY   STATUS    RESTARTS   AGE
-kafka-kafka-0   1/1     Running   0          7m26s
-kafka-kafka-1   1/1     Running   0          8m26s
-kafka-kafka-2   1/1     Running   0          8m53s
-kafka-kafka-3   1/1     Running   0          10m
-kafka-kafka-4   1/1     Running   0          9m21s
+$ kubectl get pods -l app=kafka
+NAME                     READY   STATUS    RESTARTS   AGE
+kafka-instance-kafka-0   2/2     Running   0          3h12m
+kafka-instance-kafka-1   2/2     Running   0          3h13m
+kafka-instance-kafka-2   2/2     Running   0          3h13m
+kafka-instance-kafka-3   2/2     Running   0          3h14m
+kafka-instance-kafka-4   2/2     Running   0          3h14m
 ```
 
 
@@ -84,7 +114,7 @@ kafka-kafka-4   1/1     Running   0          9m21s
 To scale vertically, we can update the broker's statefulset.
 
 ```
-> kubectl describe statefulset kafka-kafka
+$ kubectl describe statefulset kafka-kafka
 [ ... lines removed for clarity ...]
     Requests:
       cpu:      500m
@@ -97,13 +127,13 @@ To scale vertically, we can update the broker's statefulset.
 Let's increase the cpu request from `500m` to `700m` and double the memory request from `2048Mi` to `4096Mi`. Also important is increasing the limits as they cannot be lower than the requested resources. 
 
 ```
-kubectl kudo update kafka -p BROKER_CPUS=700m -p BROKER_MEM=4096Mi -p BROKER_CPUS_LIMIT=3000m -p BROKER_MEM_LIMIT=6144Mi
+$ kubectl kudo update kafka -p BROKER_CPUS=700m -p BROKER_MEM=4096Mi -p BROKER_CPUS_LIMIT=3000m -p BROKER_MEM_LIMIT=6144Mi
 ```
 
 This will initiate a rolling upgrade of the pods to a new statefulset.
 
 ```
-> kubectl describe statefulset kafka-kafka
+$ kubectl describe statefulset kafka-kafka
 [ ... lines removed for clarity ...]
     Requests:
       cpu:      700m

--- a/repository/kafka/docs/latest/upgrade.md
+++ b/repository/kafka/docs/latest/upgrade.md
@@ -61,7 +61,7 @@ kafka-1.2.1       2m6s
 Check the plan status again:
 
 ```
-$ kubectl kudo plan status --instance=kafka
+$ kubectl kudo plan status --instance=kafka-instance
 Plan(s) for "kafka-instance" in namespace "default":
 .
 └── kafka-instance (Operator-Version: "kafka-1.2.1" Active-Plan: "deploy")

--- a/repository/kafka/docs/latest/upgrade.md
+++ b/repository/kafka/docs/latest/upgrade.md
@@ -44,7 +44,7 @@ Plan(s) for "kafka-instance" in namespace "default":
 To update the Kafka cluster from version `0.1.2` to `0.2.0`:
 
 ```
-$ kubectl kudo upgrade kafka --version=1.2.1 --instance kafka-instance
+$ kubectl kudo upgrade kafka --operator-version=1.2.1 --instance kafka-instance
 
 operator.kudo.dev/kafka unchanged
 operatorversion.kudo.dev/v1beta1/kafka-1.2.1 created

--- a/repository/kafka/docs/latest/upgrade.md
+++ b/repository/kafka/docs/latest/upgrade.md
@@ -20,51 +20,70 @@ The following upgrade procedure assumes one running Kafka cluster and one Kafka 
 Check for running instances:
 
 ```
-kubectl get instances
-NAME           AGE
-kafka-fc6vzn   29h
+$ kubectl get instances
+NAME             AGE
+kafka-instance   29h
 ```
 
-We can check the plan status of our Kafka cluster `kafka-fc6vzn` with:
+We can check the plan status of our Kafka cluster `kafka-instance` with:
 ```
-kubectl kudo plan status --instance=kafka-fc6vzn
-Plan(s) for "kafka-fc6vzn" in namespace "default":
+$ kubectl kudo plan status --instance=kafka-instance
+Plan(s) for "kafka-instance" in namespace "default":
 .
-└── kafka-fc6vzn (Operator-Version: "kafka-0.1.2" Active-Plan: "kafka-fc6vzn-deploy-414458000")
-    └── Plan deploy (serial strategy) [COMPLETE]
-        └── Phase deploy-kafka (serial strategy) [COMPLETE]
-            └── Step deploy (COMPLETE)
+└── kafka-instance (Operator-Version: "kafka-1.1.0" Active-Plan: "deploy")
+    ├── Plan deploy (serial strategy) [COMPLETE]
+    │  └── Phase deploy-kafka [COMPLETE]
+    │    └── Step deploy (COMPLETE)
+    └── Plan not-allowed (serial strategy) [NOT ACTIVE]
+        └── Phase not-allowed (serial strategy) [NOT ACTIVE]
+            └── Step not-allowed (serial strategy) [NOT ACTIVE]
+                └── not-allowed [NOT ACTIVE]
 ```
-**Note:** the operator version is `kafka-0.1.2`
+**Note:** the operator version is `kafka-1.1.0`
 
 To update the Kafka cluster from version `0.1.2` to `0.2.0`:
 
 ```
-kubectl kudo upgrade kafka --version=0.2.0 --instance kafka
+$ kubectl kudo upgrade kafka --version=1.2.1 --instance kafka-instance
 
 operator.kudo.dev/kafka unchanged
-operatorversion.kudo.dev/v1beta1/kafka-0.2.0 created
+operatorversion.kudo.dev/v1beta1/kafka-1.2.1 created
 ```
 Now there are two operator versions installed:
 ```
 kubectl  get operatorversions.kudo.k8s.io
 
 NAME              AGE
-kafka-0.1.2       2d2h
-kafka-0.2.0       2m6s
+kafka-1.1.0       2d2h
+kafka-1.2.1       2m6s
 ```
 
 Check the plan status again:
 
 ```
-kubectl kudo plan status --instance=kafka
-Plan(s) for "kafka" in namespace "default":
+$ kubectl kudo plan status --instance=kafka
+Plan(s) for "kafka-instance" in namespace "default":
 .
-└── kafka (Operator-Version: "kafka-0.2.0" Active-Plan: "kafka-deploy-575561000")
-    └── Plan deploy (serial strategy) [COMPLETE]
-        └── Phase deploy-kafka (serial strategy) [COMPLETE]
-            └── Step deploy (COMPLETE)
+└── kafka-instance (Operator-Version: "kafka-1.2.1" Active-Plan: "deploy")
+    ├── Plan deploy (serial strategy) [IN_PROGRESS]
+    │   └── Phase deploy-kafka (serial strategy) [COMPLETE]
+    │       ├── Step configuration [COMPLETE]
+    │       ├── Step service [COMPLETE]
+    │       ├── Step app [COMPLETE]
+    │       └── Step addons [COMPLETE]
+    ├── Plan external-access (serial strategy) [NOT ACTIVE]
+    │   └── Phase external-access-resources (serial strategy) [NOT ACTIVE]
+    │       └── Step external [NOT ACTIVE]
+    ├── Plan mirrormaker (serial strategy) [NOT ACTIVE]
+    │   └── Phase deploy-mirror-maker (serial strategy) [NOT ACTIVE]
+    │       └── Step deploy [NOT ACTIVE]
+    ├── Plan not-allowed (serial strategy) [NOT ACTIVE]
+    │   └── Phase not-allowed (serial strategy) [NOT ACTIVE]
+    │       └── Step not-allowed [NOT ACTIVE]
+    └── Plan service-monitor (serial strategy) [NOT ACTIVE]
+        └── Phase enable-service-monitor (serial strategy) [NOT ACTIVE]
+            └── Step add-service-monitor [NOT ACTIVE]
 ```
 
-**Note:** the operator-version is now `kafka-0.2.0` meaning the Kafka Operator has successfully been upgraded.
+**Note:** the operator-version is now `kafka-1.2.1` meaning the Kafka Operator has been successfully upgraded.
 

--- a/repository/kafka/docs/latest/versions.md
+++ b/repository/kafka/docs/latest/versions.md
@@ -8,4 +8,4 @@
 
 ### KUDO Version Requirement
 
-KUDO version 0.8.0 or later
+KUDO version 0.10.0 or later

--- a/repository/kafka/docs/v1.1/install.md
+++ b/repository/kafka/docs/v1.1/install.md
@@ -20,7 +20,7 @@ kubectl kudo install zookeeper --instance=zk
 Please read the [limitations](./limitations.md) docs before creating the KUDO Kafka cluster. 
 
 ```
-kubectl kudo install kafka --instance=kafka
+kubectl kudo install kafka
 ```
 
 Verify the if the deploy plan for `--instance=kafka` is complete.

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -1,6 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 name: "kafka"
-operatorVersion: "1.2.0"
+operatorVersion: "1.2.1"
 kudoVersion: 0.10.0
 kubernetesVersion: 1.14.8
 appVersion: 2.4.0
@@ -15,23 +15,7 @@ tasks:
     kind: Apply
     spec:
       resources:
-        - serviceaccount.yaml
-        - role.yaml
-        - rolebinding.yaml
-        - clusterrole.yaml
-        - clusterrolebinding.yaml
-        - service.yaml
-        - external-service.yaml
         - pdb.yaml
-        - server.properties.yaml
-        - bootstrap.yaml
-        - metrics-config.yaml
-        - health-check.yaml
-        - enable-tls.yaml
-        - jaas-config.yaml
-        - krb5-config.yaml
-        - service-monitor.yaml
-        - user-workload.yaml
         - statefulset.yaml
   - name: mirrormaker
     kind: Apply
@@ -39,6 +23,38 @@ tasks:
       resources:
         - mirror-maker-config.yaml
         - mirror-maker.yaml
+  - name: user-workload
+    kind: Apply
+    spec:
+      resources:
+      - user-workload.yaml
+  - name: service
+    kind: Apply
+    spec:
+      resources:
+      - service.yaml
+      - service-monitor.yaml
+  - name: external-access
+    kind: Apply
+    spec:
+      resources:
+      - clusterrole.yaml
+      - clusterrolebinding.yaml
+      - external-service.yaml
+  - name: configuration
+    kind: Apply
+    spec:
+      resources:
+      - serviceaccount.yaml
+      - rolebinding.yaml
+      - role.yaml
+      - jaas-config.yaml
+      - krb5-config.yaml
+      - server.properties.yaml
+      - bootstrap.yaml
+      - metrics-config.yaml
+      - health-check.yaml
+      - enable-tls.yaml
   - name: not-allowed
     kind: Apply
     spec:
@@ -50,9 +66,20 @@ plans:
       - name: deploy-kafka
         strategy: serial
         steps:
-          - name: deploy
+          - name: configuration
+            tasks:
+              - configuration
+          - name: service
+            tasks:
+              - service
+          - name: app
             tasks:
               - deploy
+          - name: addons
+            tasks:
+              - external-access
+              - mirrormaker
+              - user-workload
   mirrormaker:
     strategy: serial
     phases:
@@ -62,6 +89,25 @@ plans:
           - name: deploy
             tasks:
               - mirrormaker
+  external-access:
+    strategy: serial
+    phases:
+      - name: external-access-resources
+        strategy: serial
+        steps:
+          - name: external
+            tasks:
+              - external-access
+              - deploy
+  service-monitor:
+    strategy: serial
+    phases:
+      - name: enable-service-monitor
+        strategy: serial
+        steps:
+        - name: add-service-monitor
+          tasks:
+            - service
   # this plan is triggered when some parameter present in limitations is updated
   # https://github.com/kudobuilder/operators/blob/master/repository/kafka/docs/latest/limitations.md
   not-allowed:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -62,6 +62,7 @@ parameters:
   - name: ADD_SERVICE_MONITOR
     description: "Create a service monitor for the kafka service"
     default: "false"
+    trigger: "service-monitor"
   - name: RUN_USER_WORKLOAD
     description: "Run dummy user workload on the kafka service"
     default: "false"
@@ -421,19 +422,23 @@ parameters:
     displayName: "Enable external advertised listeners"
     description: "Enable external advertised listeners"
     default: "false"
+    trigger: "external-access"
   - name: EXTERNAL_ADVERTISED_LISTENER_PORT
     displayName: "External advertised listener port"
     description: "External advertised listener port"
     default: "9097"
+    trigger: "external-access"
   - name: EXTERNAL_ADVERTISED_LISTENER_TYPE
     displayName: "External advertised listener load-balancer type"
     description: |
         External advertised listener load-balancer type, by default its using Node ports.
         Valid values are "NodePort" and "LoadBalancer"
     default: "NodePort"
+    trigger: "external-access"
   - name: EXTERNAL_NODE_PORT
     default: "30902"
     displayName: "External Node Port starting value."
+    trigger: "external-access"
   - name: FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS
     displayName: "fetch.purgatory.purge.interval.requests"
     description: "The purge interval (in number of requests) of the fetch request purgatory"

--- a/repository/kafka/operator/templates/clusterrole.yaml
+++ b/repository/kafka/operator/templates/clusterrole.yaml
@@ -1,4 +1,5 @@
 {{ if eq .Params.EXTERNAL_ADVERTISED_LISTENER "true" }}
+{{ if eq  .Params.EXTERNAL_ADVERTISED_LISTENER_TYPE "NodePort" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -7,4 +8,5 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]
+{{ end }}
 {{ end }}

--- a/repository/kafka/operator/templates/clusterrolebinding.yaml
+++ b/repository/kafka/operator/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{ if eq .Params.EXTERNAL_ADVERTISED_LISTENER "true" }}
+{{ if eq  .Params.EXTERNAL_ADVERTISED_LISTENER_TYPE "NodePort" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -11,4 +12,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Name }}
   namespace: {{ .Namespace }}
+{{ end }}
 {{ end }}

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -47,6 +47,37 @@ spec:
             - --web.listen-address=0.0.0.0:{{ .Params.KAFKA_NODE_EXPORTER_PORT }}
             - --web.disable-exporter-metrics
             - --collector.filesystem
+            - --no-collector.arp
+            - --no-collector.bcache
+            - --no-collector.bonding
+            - --no-collector.conntrack
+            - --no-collector.cpu
+            - --no-collector.cpufreq
+            - --no-collector.diskstats
+            - --no-collector.edac
+            - --no-collector.entropy
+            - --no-collector.filefd
+            - --no-collector.hwmon
+            - --no-collector.infiniband
+            - --no-collector.ipvs
+            - --no-collector.loadavg
+            - --no-collector.mdadm
+            - --no-collector.meminfo
+            - --no-collector.netclass
+            - --no-collector.netdev
+            - --no-collector.netstat
+            - --no-collector.nfs
+            - --no-collector.nfsd
+            - --no-collector.pressure
+            - --no-collector.sockstat
+            - --no-collector.stat
+            - --no-collector.textfile
+            - --no-collector.time
+            - --no-collector.timex
+            - --no-collector.uname
+            - --no-collector.vmstat
+            - --no-collector.xfs
+            - --no-collector.zfs
         {{ end }}
         - name: k8skafka
           imagePullPolicy: Always

--- a/repository/kafka/tests/kafka-upgrade-test/01-install.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/01-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.2.0
+    name: kafka-1.2.1
     namespace: default
     kind: OperatorVersion
   name: "kafka"

--- a/repository/kafka/tests/kafka-upgrade-test/02-resize.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/02-resize.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.2.0
+    name: kafka-1.2.1
     namespace: default
     kind: OperatorVersion
   name: "kafka"


### PR DESCRIPTION
This PR:

- introduces more steps and plans to better distribute the Kafka deploy and updates. Taking into account features like external-access and adding service monitor. This fixes few bugs where a task failure would result in step failure loop, with errors like next one:
```
A transient error when executing task deploy.deploy-kafka.deploy.deploy. Will retry. clusterrolebindings.rbac.authorization.k8s.io "kafka-instance-clusterscope-binding" already exists
```
- removes almost all collectors from the node-exporter of kafka, except the `filesystem`, which is why we added the node-exporter at first place.
- uses references to KUDO Kafka instance with default name `kafka-instance`. This fixes the issue https://github.com/kudobuilder/operators/issues/186 for KUDO Kafka
- removes the need of `clusterrole` and only adds it when the Nodeport type service is enabled. Because this is the only use case where we need to read from the Kubernetes node, the external IP address
- unify the way of docs of cli commands and use `$` for each command in docs and remove `>` or use of space 

This PR doesn't bump the docs to `v1.2` directory to keep this PR clean. Before releasing `v1.2.1` I will open a separate PR bump the docs from `latest` to `v1.2` and remove  the `v1.0` directory