### PR TITLE
zookeeper: update docs to 0.3.0

### DIFF
--- a/repository/zookeeper/README.md
+++ b/repository/zookeeper/README.md
@@ -4,12 +4,11 @@ The KUDO Zookeeper operator creates, configures and manages [Apache Zookeeper](h
 
 ## Getting started
 
-The latest stable version of Zookeeper operator is `0.2.0`
+The latest stable version of Zookeeper operator is `0.3.0`
 
 ## Version Chart
 
 | KUDO Zookeeper Version | Apache Zookeeper Version |
-| ------------------ | -------------------- |
-| 0.1.0              | 3.4.10               |
-| 0.2.0              | 3.4.14               |
-| latest             | 3.4.14               |
+| ---------------------- | ------------------------ |
+| 0.3.0                  | 3.4.14                   |
+| latest                 | 3.4.14                   |

--- a/repository/zookeeper/docs/latest/install.md
+++ b/repository/zookeeper/docs/latest/install.md
@@ -13,15 +13,15 @@ Requirements:
 Please read the [limitations](./limitations.md) docs before creating the KUDO Zookeeper cluster.
 
 ```
-kubectl kudo install zookeeper --instance=zk
+kubectl kudo install zookeeper
 ```
 
-Verify the if the deploy plan for `--instance=zk` is complete.
+Verify the if the deploy plan for `--instance=zookeeper-instance`, default instance name, is complete.
 ```
-kubectl kudo plan status --instance=zk
-Plan(s) for "zk" in namespace "default":
+kubectl kudo plan status --instance=zookeeper-instance
+Plan(s) for "zookeeper-instance" in namespace "default":
 .
-└── zk (Operator-Version: "zookeeper-0.2.0" Active-Plan: "deploy")
+└── zookeeper-instance (Operator-Version: "zookeeper-0.3.0" Active-Plan: "deploy")
     ├── Plan deploy (serial strategy) [COMPLETE]
     │   ├── Phase zookeeper [COMPLETE]
     │   │   └── Step deploy (COMPLETE)


### PR DESCRIPTION
update docs to use version 0.3.0 instead of 0.2.0 which KUDO `0.10.0` doesn't support.


Signed-off-by: Zain Malik <zmalikshxil@gmail.com>