### PR TITLE
Fix the bug of svc name error

### DIFF
--- a/repository/redis/operator/templates/configmap.yaml
+++ b/repository/redis/operator/templates/configmap.yaml
@@ -1,7 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Name }}-redis
+  namespace: {{ .Namespace }}
+  name: {{ .Name }}-{{ .OperatorName }}
+  labels:
+    app: redis
+    redis: {{ .OperatorName }}
+    instance: {{ .Name }}
 data:
   update-node.sh: |
     #!/bin/sh

--- a/repository/redis/operator/templates/init.yaml
+++ b/repository/redis/operator/templates/init.yaml
@@ -2,11 +2,16 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Namespace }}
-  name: {{ .PlanName }}-job
+  name: {{ .PlanName }}-{{ .Name }}-{{ .OperatorName }}-job
+  labels:
+    app: redis
+    redis: {{ .OperatorName }}
+    instance: {{ .Name }}
+    plan: {{ .PlanName }}
 spec:
   template:
     metadata:
-      name: {{ .PlanName }}-job
+      name: {{ .PlanName }}-{{ .Name }}-{{ .OperatorName }}-job
     spec:
       restartPolicy: OnFailure
       containers:
@@ -16,4 +21,4 @@ spec:
         command:
         - /bin/sh
         - -c
-        - 'echo yes | redis-cli -x -h {{ .Name }}-svc --cluster create --cluster-replicas 1 $(i=0; while [ $i -lt {{ .Params.masters | mul 2 }} ]; do printf $(nslookup {{ .Name }}-{{ .Name }}-${i}.{{ .Name }}-svc | grep "Address" | awk "{ print \$3 }")":{{ .Params.client_port }} "; i=$((i+1)); done)'
+        - 'echo yes | redis-cli -x -h {{ .Name }}-{{ .OperatorName }}-svc --cluster create --cluster-replicas 1 $(i=0; while [ $i -lt {{ .Params.masters | mul 2 }} ]; do printf $(nslookup {{ .Name }}-{{ .OperatorName }}-${i}.{{ .Name }}-{{ .OperatorName }}-svc | grep "Address" | awk "{ print \$3 }")":{{ .Params.client_port }} "; i=$((i+1)); done)'

--- a/repository/redis/operator/templates/pdb.yaml
+++ b/repository/redis/operator/templates/pdb.yaml
@@ -1,10 +1,16 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: pdb
+  namespace: {{ .Namespace }}
+  name: {{ .Name }}-{{ .OperatorName }}-pdb
+  labels:
+    app: redis
+    redis: {{ .OperatorName }}
+    instance: {{ .Name }}
 spec:
   selector:
     matchLabels:
       app: redis
+      redis: {{ .OperatorName }}
       instance: {{ .Name }}
   minAvailable: 2

--- a/repository/redis/operator/templates/service.yaml
+++ b/repository/redis/operator/templates/service.yaml
@@ -1,7 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: svc
+  namespace: {{ .Namespace }}
+  name: {{ .Name }}-{{ .OperatorName }}-svc
+  labels:
+    app: redis
+    redis: {{ .OperatorName }}
+    instance: {{ .Name }}
 spec:
   type: ClusterIP
   ports:
@@ -13,4 +18,5 @@ spec:
     name: gossip
   selector:
     app: redis
+    redis: {{ .OperatorName }}
     instance: {{ .Name }}

--- a/repository/redis/operator/templates/statefulset.yaml
+++ b/repository/redis/operator/templates/statefulset.yaml
@@ -1,23 +1,26 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Name }}
   namespace: {{ .Namespace }}
+  name: {{ .Name }}-{{ .OperatorName }}
   labels:
     app: redis
     redis: {{ .OperatorName }}
+    instance: {{ .Name }}
 spec:
-  serviceName: {{ .Name }}-svc
+  serviceName: {{ .Name }}-{{ .OperatorName }}-svc
   replicas: {{ .Params.masters | mul 2 }}
   selector:
     matchLabels:
       app: redis
       redis: {{ .OperatorName }}
+      instance: {{ .Name }}
   template:
     metadata:
       labels:
         app: redis
         redis: {{ .OperatorName }}
+        instance: {{ .Name }}
     spec:
       containers:
       - name: redis
@@ -43,7 +46,7 @@ spec:
       volumes:
       - name: conf
         configMap:
-          name: {{ .Name }}-redis
+          name: {{ .Name }}-{{ .OperatorName }}
           defaultMode: 0755
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
After we install the redis
```
kubectl kudo install redis
```

The `init` task's job's pod will crash, we will get some error logs like this

```
nslookup: can't resolve 'redis-instance-redis-instance-5.redis-instance-svc': Name does not resolve
Could not connect to Redis at :6379: Name does not resolve
```

1. the redis service name is just `svc`
https://github.com/kudobuilder/operators/blob/3960045edd51358af920e1ad899a253bef3ba8b6/repository/redis/operator/templates/service.yaml#L4

2. the job's pod lookup a service name look like `{{ .Name }}-svc`
https://github.com/kudobuilder/operators/blob/3960045edd51358af920e1ad899a253bef3ba8b6/repository/redis/operator/templates/init.yaml#L19


In addition, I think we should standardize the naming of Name and Label