### PR TITLE
kafka: add auto TLS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ifeq "$(MACHINE)" "x86_64"
 endif
 
 export PATH := $(shell pwd)/bin/:$(PATH)
+export KUBECONFIG := $(shell pwd)/kubeconfig
 
 bin/:
 	mkdir -p bin/

--- a/repository/kafka/docs/latest/security.md
+++ b/repository/kafka/docs/latest/security.md
@@ -46,6 +46,8 @@ kubectl kudo install kafka \
     -p USE_AUTO_TLS_CERTIFICATE=true
 ```
 
+:warning: If both `USE_AUTO_TLS_CERTIFICATE` and `TLS_SECRET_NAME` is provided, the operator will give precedence to Auto TLS certificates over the user provided TLS secret.
+
 ## Authentication
 
 KUDO Kafka supports two authentication mechanisms, TLS and Kerberos. The two are supported independently and may not be combined. If both TLS and Kerberos authentication are enabled, the service will use Kerberos authentication

--- a/repository/kafka/docs/latest/security.md
+++ b/repository/kafka/docs/latest/security.md
@@ -8,6 +8,8 @@ By default, KUDO Kafka brokers use the plaintext protocol for its inter-broker c
 
 ### Enabling  TLS encryption
 
+#### Manually generating certificate
+
 Create the TLS certificate to be used for Kafka TLS encryptions
 
 ```
@@ -29,6 +31,19 @@ $ kubectl kudo install kafka \
     -p TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT=false \
     -p SSL_AUTHENTICATION_ENABLED=false \
     -p TLS_SECRET_NAME=kafka-tls
+```
+
+#### Using Auto certificate generation
+
+KUDO Kafka can automatically generate a CA certificate and create secrets which are then used by the brokers to set up Kafka transport encryption. 
+
+```
+kubectl kudo install kafka \
+    --instance=kafka --namespace=kudo-kafka \
+    -p TRANSPORT_ENCRYPTION_ENABLED=true \
+    -p TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT=false \
+    -p SSL_AUTHENTICATION_ENABLED=false \
+    -p USE_AUTO_TLS_CERTIFICATE=true
 ```
 
 ## Authentication

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -629,7 +629,10 @@ parameters:
   - name: TLS_SECRET_NAME
     default: "kafka-tls"
     displayName: "kafka-tls"
-    description: "The secret that contains TLS certificate and is mounted as a volume to make them available to the brokers."
+  - name: USE_AUTO_TLS_CERTIFICATE
+    default: "false"
+    displayName: "kafka-auto-tls"
+    description: "The operator will auto create secrets that contains TLS certificate and is mounted as a volume to make them available to the brokers."
   - name: CUSTOM_SERVER_PROPERTIES_CM_NAME
     displayName: "custom server properties configmap name"
     description: "The properties present in this configmap will be appended to the Kafka server properties"

--- a/repository/kafka/operator/templates/cert-generator.yaml
+++ b/repository/kafka/operator/templates/cert-generator.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+spec:
+  volumes:
+  - name: cert-out
+    emptyDir: {}
+  initContainers:
+    - name: init
+      image: mesosphere/kafka:1.1.0-2.4.0
+      command: [ "/bin/sh", "-c" ]
+      args:
+        - openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=KudoKafkaCA" -days 365
+      volumeMounts:
+        - name: cert-out
+          mountPath: /tmp

--- a/repository/kafka/operator/templates/enable-tls.yaml
+++ b/repository/kafka/operator/templates/enable-tls.yaml
@@ -10,8 +10,13 @@ data:
     mkdir -p /home/kafka/tls
     pushd /home/kafka/tls
     # COPY CA AUTHORITY CERTIFICATE AND KEY OBTAINED FROM SECRETS
+    {{ if eq .Params.USE_AUTO_TLS_CERTIFICATE "true" }}
+    cp /etc/tls/certs/crt/tls.crt /home/kafka/tls/tls.crt
+    cp /etc/tls/certs/key/tls.key /home/kafka/tls/tls.key
+    {{ else }}
     cp /etc/tls/certs/tls.crt /home/kafka/tls/tls.crt
     cp /etc/tls/certs/tls.key /home/kafka/tls/tls.key
+    {{ end }}
     # GENERATE KEYSTORE AND TRUSTSTORE
     keytool -keystore kafka.server.keystore.jks \
             -alias localhost \

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -185,8 +185,15 @@ spec:
               readOnly: true
           {{ end }}
           {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+          {{ if eq .Params.USE_AUTO_TLS_CERTIFICATE "true" }}
+            - name: kafka-tls-key
+              mountPath: /etc/tls/certs/key
+            - name: kafka-tls-crt
+              mountPath: /etc/tls/certs/crt
+          {{ else }}
             - name: kafka-tls
               mountPath: /etc/tls/certs
+          {{ end }}
             - name: enable-tls
               mountPath: /etc/tls/bin
           {{ end }}
@@ -259,9 +266,18 @@ spec:
             secretName: {{ .Params.KERBEROS_KEYTAB_SECRET }}
         {{ end }}
         {{ if eq .Params.TRANSPORT_ENCRYPTION_ENABLED "true" }}
+        {{ if eq .Params.USE_AUTO_TLS_CERTIFICATE "true" }}
+        - name: kafka-tls-key
+          secret:
+            secretName: {{ .Pipes.privatekey }}
+        - name: kafka-tls-crt
+          secret:
+            secretName: {{ .Pipes.certificate }}
+        {{ else }}
         - name: kafka-tls
           secret:
             secretName: {{ .Params.TLS_SECRET_NAME }}
+        {{ end }}
         - name: enable-tls
           configMap:
             name:  {{ .Name }}-enable-tls


### PR DESCRIPTION
This PR-

1. Uses KUDO pipe tasks to generate certificates when `USE_AUTO_TLS_CERTIFICATE` parameter is set to `true`.
2. Updated docs
3. Tests added https://github.com/mesosphere/kudo-kafka-operator/pull/35