### PR TITLE
Restructure Spark for proper status of deployment

### DIFF
--- a/repository/spark/operator/operator.yaml
+++ b/repository/spark/operator/operator.yaml
@@ -1,39 +1,99 @@
 apiVersion: kudo.dev/v1beta1
-name: "spark"
-operatorVersion: "beta1"
-kudoVersion: 0.10.0
+appVersion: 2.4.3
 kubernetesVersion: 1.15.0
-appVersion: "2.4.3"
+kudoVersion: 0.10.0
 maintainers:
-  - name: Anton Kirillov
-    email: akirillov@d2iq.com
-  - name: Uladzimir Krautsou
-    email: ukrautsou.c@d2iq.com
-url: https://spark.apache.org/
-tasks:
-  - name: deploy
-    kind: Apply
-    spec:
-      resources:
-        - spark-operator-crds.yaml
-        - spark-operator-rbac.yaml
-        - spark-operator-serviceaccount.yaml
-        - spark-rbac.yaml
-        - spark-serviceaccount.yaml
-        - webhook-init-job.yaml
-        - spark-operator-deployment.yaml
-        - webhook-service.yaml
-        - spark-history-server-deployment.yaml
-        - spark-history-server-service.yaml
-        - spark-monitoring.yaml
-
+- email: akirillov@d2iq.com
+  name: Anton Kirillov
+- email: ukrautsou.c@d2iq.com
+  name: Uladzimir Krautsou
+name: spark
+operatorVersion: beta1
 plans:
   deploy:
-    strategy: serial
     phases:
-      - name: deploy-spark
-        strategy: serial
-        steps:
-          - name: deploy
-            tasks:
-              - deploy
+    - name: preconditions
+      steps:
+      - name: crds
+        tasks:
+        - crds
+      - name: service-account
+        tasks:
+        - service-account
+      - name: rbac
+        tasks:
+        - rbac
+      strategy: serial
+    - name: spark
+      steps:
+      - name: spark
+        tasks:
+        - spark
+      strategy: serial
+    - name: webhook
+      steps:
+      - name: webhook
+        tasks:
+        - webhook
+      strategy: serial
+    - name: monitoring
+      steps:
+      - name: monitoring
+        tasks:
+        - monitoring
+      strategy: serial
+    - name: history
+      steps:
+      - name: history-deploy
+        tasks:
+        - history-deploy
+      - name: history-service
+        tasks:
+        - history-service
+      strategy: serial
+    strategy: serial
+tasks:
+- kind: Apply
+  name: crds
+  spec:
+    resources:
+    - spark-operator-crds.yaml
+- kind: Apply
+  name: service-account
+  spec:
+    resources:
+    - spark-serviceaccount.yaml
+    - spark-operator-serviceaccount.yaml
+- kind: Apply
+  name: rbac
+  spec:
+    resources:
+    - spark-operator-rbac.yaml
+    - spark-rbac.yaml
+- kind: Apply
+  name: spark
+  spec:
+    resources:
+    - spark-operator-deployment.yaml
+- kind: Apply
+  name: webhook
+  spec:
+    resources:
+    - webhook-init-job.yaml
+    - webhook-service.yaml
+- kind: Apply
+  name: monitoring
+  spec:
+    resources:
+    - spark-monitoring.yaml
+- kind: Apply
+  name: history-deploy
+  spec:
+    resources:
+    - spark-history-server-deployment.yaml
+- kind: Apply
+  name: history-service
+  spec:
+    resources:
+    - spark-history-server-service.yaml
+url: https://spark.apache.org/

--- a/repository/spark/operator/operator.yaml
+++ b/repository/spark/operator/operator.yaml
@@ -26,17 +26,17 @@ plans:
         tasks:
         - rbac
       strategy: serial
-    - name: spark
-      steps:
-      - name: spark
-        tasks:
-        - spark
-      strategy: serial
     - name: webhook
       steps:
       - name: webhook
         tasks:
         - webhook
+      strategy: serial
+    - name: spark
+      steps:
+      - name: spark
+        tasks:
+        - spark
       strategy: serial
     - name: monitoring
       steps:

--- a/repository/spark/operator/operator.yaml
+++ b/repository/spark/operator/operator.yaml
@@ -3,10 +3,12 @@ appVersion: 2.4.3
 kubernetesVersion: 1.15.0
 kudoVersion: 0.10.0
 maintainers:
-- email: akirillov@d2iq.com
-  name: Anton Kirillov
-- email: ukrautsou.c@d2iq.com
-  name: Uladzimir Krautsou
+- name: Anton Kirillov
+  email: akirillov@d2iq.com
+- name: Alexander Lembiewski
+  email: alembiyeuski.c@d2iq.com
+- name: Ken Sipe
+  email: ken@d2iq.com
 name: spark
 operatorVersion: beta1
 plans:

--- a/repository/spark/operator/params.yaml
+++ b/repository/spark/operator/params.yaml
@@ -45,7 +45,7 @@ parameters:
   ## Metrics
   - name: enableMetrics
     description: "Enable metrics"
-    default: true
+    default: false
     displayName: "Enable metrics"
 
   - name: operatorMetricsPort
@@ -193,4 +193,3 @@ parameters:
     description: "Leader election retry period."
     default: 4s
     displayName: "Leader election retry period"
-


### PR DESCRIPTION

Reason for the failures aside (to be address elsewhere)... having all manifests under one task should be discouraged.   The result of 1 manifest having an issue is to have all the manifests re-applied. resulting in odd behavior.

Prior to this change status of an install looked like:

```
kubectl kudo plan status --instance=spark
Plan(s) for "spark" in namespace "default":
.
└── spark (Operator-Version: "spark-beta1" Active-Plan: "deploy")
    └── Plan deploy (serial strategy) [IN_PROGRESS]
        └── Phase deploy-spark (serial strategy) [IN_PROGRESS]
            └── Step deploy [ERROR] (A transient error when executing task deploy.deploy-spark.deploy.deploy. Will retry. customresourcedefinitions.apiextensions.k8s.io "sparkapplications.sparkoperator.k8s.io" already exists)
```

after this change:

```
 kubectl kudo plan status --instance=spark
Plan(s) for "spark" in namespace "default":
.
└── spark (Operator-Version: "spark-beta1" Active-Plan: "deploy")
    └── Plan deploy (serial strategy) [COMPLETE]
        ├── Phase preconditions (serial strategy) [COMPLETE]
        │   ├── Step crds [COMPLETE]
        │   ├── Step service-account [COMPLETE]
        │   └── Step rbac [COMPLETE]
        ├── Phase spark (serial strategy) [COMPLETE]
        │   └── Step spark [COMPLETE]
        ├── Phase webhook (serial strategy) [COMPLETE]
        │   └── Step webhook [COMPLETE]
        ├── Phase monitoring (serial strategy) [COMPLETE]
        │   └── Step monitoring [COMPLETE]
        └── Phase history (serial strategy) [COMPLETE]
            ├── Step history-deploy [COMPLETE]
            └── Step history-service [COMPLETE]
```

Also... there must be more needed to make metrics work... I would rather everything work by default then add params for additional support.  

Signed-off-by: Ken Sipe <kensipe@gmail.com>