### PR TITLE
Updated operator akka shopping cart to the latest APIs version

### DIFF
--- a/templates/akka/operator-shoppingcart/operator.yaml
+++ b/templates/akka/operator-shoppingcart/operator.yaml
@@ -7,11 +7,13 @@ maintainers:
   - name: Michael Beisiegel
     email: michael.beisiegel@gmail.com
 tasks:
-  deploy-cluster:
-    resources:
-      - rolebinding.yaml
-      - service.yaml
-      - deployment.yaml
+  - name: deploy-cluster
+    kind: Apply
+    spec:
+      resources:
+        - rolebinding.yaml
+        - service.yaml
+        - deployment.yaml
 plans:
   deploy:
     strategy: serial

--- a/templates/akka/operator-shoppingcart/params.yaml
+++ b/templates/akka/operator-shoppingcart/params.yaml
@@ -1,2 +1,4 @@
-NODE_COUNT:
-  default: "3"
+apiVersion: kudo.dev/v1beta1
+parameters:
+  - name: NODE_COUNT
+    default: "3"


### PR DESCRIPTION
While Akka operator is using the latest version of kudo, while shopping cart one was using the previous version