### PR TITLE
Spark: Using a Secret for setting AWS credentials in Spark History Server

### DIFF
--- a/repository/spark/docs/latest/configuration.md
+++ b/repository/spark/docs/latest/configuration.md
@@ -81,7 +81,7 @@ This section describes the steps required to provide an access to S3 when using 
 or accessing S3 buckets from Spark workloads. 
 With this method all sensitive data is stored as Kubernetes Secret and mounted to pods via environment variables.
 
-First, you need to convert AWS credentials to base64 as follows:
+In order to store AWS credentials in a `Secret`, the credentials should be converted to base64 first:
 ```bash
 $ echo "<AWS_ACCESS_KEY_ID>" | base64                    
   QVdTX0FDQ0VTU19LRVlfSUQK
@@ -104,7 +104,7 @@ Note: a Secret must be in the same namespace as an Spark Operator.
 
 To read more about Secrets, refer to the [official K8s documentation](https://kubernetes.io/docs/concepts/configuration/secret/).
 
-Here is the example using a Secret to pass AWS credentials as environment variables to `SparkApplication`: 
+Here is an example configuration which uses a `Secret` to pass AWS credentials as environment variables to `SparkApplication`: 
 ```yaml
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication

--- a/repository/spark/docs/latest/configuration.md
+++ b/repository/spark/docs/latest/configuration.md
@@ -77,8 +77,7 @@ created or exist prior to submission of Spark Applications. `Role` configuration
 available in [spark-rbac.yaml](../../operator/templates/spark-rbac.yaml) template file.
 
 ### Integration with AWS S3
-This section describes the steps required to provide an access to S3 when using Spark History server 
-or accessing S3 buckets from Spark workloads. 
+This section describes the steps required for configuring secure access to S3 buckets for Spark workloads and Spark History server.
 With this method all sensitive data is stored as Kubernetes Secret and mounted to pods via environment variables.
 
 In order to store AWS credentials in a `Secret`, the credentials should be converted to base64 first:

--- a/repository/spark/docs/latest/history-server.md
+++ b/repository/spark/docs/latest/history-server.md
@@ -16,7 +16,7 @@ kubectl kudo install spark --instance=spark-operator \
 ```
 This will deploy a Pod and Service for the `Spark History Server` with the `Spark Event Log` directory configured via the `historyServerFsLogDirectory` parameter. Spark Operator also supports Persistent Volume Claim (PVC) based storage. There is a parameter `historyServerPVCName` to pass the name of the PVC. Make sure that provided PVC should have `ReadWriteMany` [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) supported.
 
-If you want to write and read event logs to/from an S3 bucket, you can do the following:
+To configure S3 for event log storage it is recommended to store AWS security credentials in a `Secret` in the following way:
 1) Create a `Secret` which will contain Spark configuration (file name is important):
 ```bash
 $ cat << 'EOF' >> spark-defaults.conf
@@ -39,10 +39,10 @@ kubectl kudo install spark --instance=spark-operator \
 
 When submitting Spark Applications to the Operator with Spark History server enabled, you need to provide additional 
 configuration depending on storage type you are using for event logging. 
-For S3, an application configuration spec could be the following:
+The following steps are required for configuring Spark Application event log storage in S3:
 
-1) Create a `Secret` with AWS credentials as described [here](configuration.md#integration-with-aws-s3).
-2) SparkApplication configuration could be as the following:
+1) Create a `Secret` with AWS credentials as described in [Integration with AWS S3](configuration.md#integration-with-aws-s3) Operator documentation.
+2) Create a `SparkApplication` configuration with AWS credentials environment variables populated from a `Secret` created at the previous step. Here's an example:
 ```yaml
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication

--- a/repository/spark/docs/latest/history-server.md
+++ b/repository/spark/docs/latest/history-server.md
@@ -37,8 +37,8 @@ kubectl kudo install spark --instance=spark-operator \
 
 ## Creating Spark Application
 
-When submitting Spark Applications to the Operator with Spark History server enabled, you need to provide additional 
-configuration depending on storage type you are using for event logging. 
+When Spark History server is enabled, an additional configuration such as security credentials can be required for 
+accessing the storage backend being used for event logging. 
 The following steps are required for configuring Spark Application event log storage in S3:
 
 1) Create a `Secret` with AWS credentials as described in [Integration with AWS S3](configuration.md#integration-with-aws-s3) Operator documentation.

--- a/repository/spark/operator/params.yaml
+++ b/repository/spark/operator/params.yaml
@@ -114,8 +114,8 @@ parameters:
     default: ""
     displayName: "Spark History Server Persistent Volume Claim Name"
 
-  - name: awsCredentialsSecretName
-    description: "Name of a Secret with AWS credentials. The secret should be in the same namespace as an Operator."
+  - name: historyServerSparkConfSecret
+    description: "Name of a Secret with Spark config file. The secret should be in the same namespace as an Operator."
     default: ""
     displayName: "Name of a Secret with AWS credentials"
 

--- a/repository/spark/operator/params.yaml
+++ b/repository/spark/operator/params.yaml
@@ -114,6 +114,11 @@ parameters:
     default: ""
     displayName: "Spark History Server Persistent Volume Claim Name"
 
+  - name: awsCredentialsSecretName
+    description: "Name of a Secret with AWS credentials. The secret should be in the same namespace as an Operator."
+    default: ""
+    displayName: "Name of a Secret with AWS credentials"
+
   ## Miscellaneous
   - name: sparkJobNamespace
     description: "Namespace for Spark Applications. Defaults to Operator namespace"

--- a/repository/spark/operator/params.yaml
+++ b/repository/spark/operator/params.yaml
@@ -115,7 +115,7 @@ parameters:
     displayName: "Spark History Server Persistent Volume Claim Name"
 
   - name: historyServerSparkConfSecret
-    description: "Name of a Secret with Spark config file. The secret should be in the same namespace as an Operator."
+    description: "Name of a Secret with Spark config file. The secret should be in the same namespace as the Operator."
     default: ""
     displayName: "Name of a Secret with AWS credentials"
 

--- a/repository/spark/operator/params.yaml
+++ b/repository/spark/operator/params.yaml
@@ -117,7 +117,7 @@ parameters:
   - name: historyServerSparkConfSecret
     description: "Name of a Secret with Spark config file. The secret should be in the same namespace as the Operator."
     default: ""
-    displayName: "Name of a Secret with AWS credentials"
+    displayName: "Name of a Secret with Spark History Server configuration file"
 
   ## Miscellaneous
   - name: sparkJobNamespace

--- a/repository/spark/operator/templates/spark-history-server-deployment.yaml
+++ b/repository/spark/operator/templates/spark-history-server-deployment.yaml
@@ -39,6 +39,24 @@ spec:
           value: "true"
         - name: SPARK_HISTORY_OPTS
           value: "{{ .Params.historyServerOpts }} -Dspark.history.fs.logDirectory={{ .Params.historyServerFsLogDirectory }} -Dspark.history.fs.cleaner.enabled={{ .Params.historyServerCleanerEnabled }} -Dspark.history.fs.cleaner.interval={{ .Params.historyServerCleanerInterval }} -Dspark.history.fs.cleaner.maxAge={{ .Params.historyServerCleanerMaxAge }}"
+        {{- if .Params.awsCredentialsSecretName }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Params.awsCredentialsSecretName }}
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Params.awsCredentialsSecretName }}
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_SESSION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Params.awsCredentialsSecretName }}
+              key: AWS_SESSION_TOKEN
+              optional: true
+        {{- end }}
         ports:
         - containerPort: 18080
           name: "history-server"

--- a/repository/spark/operator/templates/spark-history-server-deployment.yaml
+++ b/repository/spark/operator/templates/spark-history-server-deployment.yaml
@@ -39,34 +39,25 @@ spec:
           value: "true"
         - name: SPARK_HISTORY_OPTS
           value: "{{ .Params.historyServerOpts }} -Dspark.history.fs.logDirectory={{ .Params.historyServerFsLogDirectory }} -Dspark.history.fs.cleaner.enabled={{ .Params.historyServerCleanerEnabled }} -Dspark.history.fs.cleaner.interval={{ .Params.historyServerCleanerInterval }} -Dspark.history.fs.cleaner.maxAge={{ .Params.historyServerCleanerMaxAge }}"
-        {{- if .Params.awsCredentialsSecretName }}
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Params.awsCredentialsSecretName }}
-              key: AWS_ACCESS_KEY_ID
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Params.awsCredentialsSecretName }}
-              key: AWS_SECRET_ACCESS_KEY
-        - name: AWS_SESSION_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Params.awsCredentialsSecretName }}
-              key: AWS_SESSION_TOKEN
-              optional: true
-        {{- end }}
         ports:
         - containerPort: 18080
           name: "history-server"
-      {{- if .Params.historyServerPVCName }}
         volumeMounts:
-        - mountPath: "{{ .Params.historyServerFsLogDirectory }}"
-          name: history-server-storage
+          - name: spark-conf
+            mountPath: "/opt/spark/conf"
+            readOnly: true
+          {{- if .Params.historyServerPVCName }}
+          - mountPath: "{{ .Params.historyServerFsLogDirectory }}"
+            name: history-server-storage
+          {{- end }}
       volumes:
-      - name: history-server-storage
-        persistentVolumeClaim:
-          claimName: {{ .Params.historyServerPVCName }}
-      {{- end }}
+        - name: spark-conf
+          secret:
+            secretName: {{ .Params.historyServerSparkConfSecret }}
+            optional: true
+        {{- if .Params.historyServerPVCName }}
+        - name: history-server-storage
+          persistentVolumeClaim:
+            claimName: {{ .Params.historyServerPVCName }}
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR introduces the new operator parameter  `awsCredentialsSecretName`, which is the name of a `Secret` for getting AWS credentials for Spark History Server.

Currently, AWS credentials can only be passed to Spark History Server via `spark.hadoop.fs.s3a.*` properties in `historyServerOpts` during the installation. Although this solution will work, it is not optimal because sensitive data must be passed un-encrypted via the command-line.
The solution to this is to store sensitive data in Kubernetes Secrets and then mount values as environment variables to pods.

Changes:
- Introduced `awsCredentialsSecretName` for SHS
- Updated Spark History docs
- Added section describing how to create a Secret with AWS credentials and then use it in Spark Application

Tests can be found here: https://github.com/mesosphere/kudo-spark-operator/pull/88