### PR TITLE
Use task type 'Dummy' for not-allowed task

### DIFF
--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -56,7 +56,7 @@ tasks:
       - health-check.yaml
       - enable-tls.yaml
   - name: not-allowed
-    kind: Apply
+    kind: Dummy
     spec:
       resources:
 plans:

--- a/repository/zookeeper/operator/operator.yaml
+++ b/repository/zookeeper/operator/operator.yaml
@@ -35,7 +35,7 @@ tasks:
       resources:
         - validation.yaml
   - name: not-allowed
-    kind: Apply
+    kind: Dummy
     spec:
       resources:
 plans:


### PR DESCRIPTION
The 'not-allowed' task should be of type 'Dummy' as it has an empty resource list, which triggers an error when the task would be executed.

This will be more visible when https://github.com/kudobuilder/kudo/pull/1324 is merged, as the issue will then show up on `k kudo package verify`