### PR TITLE
kafka: fix operator.yaml for autoTLS

### DIFF
--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -23,6 +23,17 @@ tasks:
       resources:
         - mirror-maker-config.yaml
         - mirror-maker.yaml
+  - name: generate-tls-certificates
+    kind: Pipe
+    spec:
+      pod: cert-generator.yaml
+      pipe:
+        - file: /tmp/tls.key
+          kind: Secret
+          key: privatekey
+        - file: /tmp/tls.crt
+          kind: Secret
+          key: certificate
   - name: user-workload
     kind: Apply
     spec:
@@ -66,6 +77,9 @@ plans:
       - name: deploy-kafka
         strategy: serial
         steps:
+          - name: generate-tls-certificates
+            tasks:
+              - generate-tls-certificates 
           - name: configuration
             tasks:
               - configuration


### PR DESCRIPTION
This PR fixes the operator yaml to include the tls pipe task declaration 

Signed-off-by: Shubhanil Bag <shubhanil.bag@gmail.com>