### PR TITLE
Fix broken links

### DIFF
--- a/repository/cassandra/3.11/README.md
+++ b/repository/cassandra/3.11/README.md
@@ -43,12 +43,12 @@ kubectl kudo install cassandra
 
 ## Documentation
 
-- [Installing](/docs/installing.md)
-- [Accessing](/docs/accessing.md)
-- [Managing](/docs/managing.md)
-- [Upgrading](/docs/upgrading.md)
-- [Monitoring](/docs/monitoring.md)
-- [Parameters reference](/docs/parameters.md)
+- [Installing](./docs/installing.md)
+- [Accessing](./docs/accessing.md)
+- [Managing](./docs/managing.md)
+- [Upgrading](./docs/upgrading.md)
+- [Monitoring](./docs/monitoring.md)
+- [Parameters reference](./docs/parameters.md)
 
 ## Version Chart
 


### PR DESCRIPTION
Currently, the links in https://github.com/kudobuilder/operators/tree/master/repository/cassandra/3.11/docs#documentation are borken. So I fixed them
