### PR TITLE
Remove the workaround KUBECONFIG setting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ ifeq "$(MACHINE)" "x86_64"
 endif
 
 export PATH := $(shell pwd)/bin/:$(PATH)
-export KUBECONFIG := $(shell pwd)/kubeconfig
 
 bin/:
 	mkdir -p bin/


### PR DESCRIPTION
This removes the workaround for #205 added in #201 in favor of the fix that is
implemented in test harness itself in
https://github.com/kudobuilder/kudo/pull/1334

NOTE: Merging this needs to wait for a KUDO release with the above PR merged.