### PR TITLE
Facilitate deploying multiple MySQL instances

### DIFF
--- a/repository/mysql/operator/operator.yaml
+++ b/repository/mysql/operator/operator.yaml
@@ -1,6 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 name: "mysql"
-operatorVersion: "0.2.0"
+operatorVersion: "0.3.0"
 kudoVersion: 0.10.0
 kubernetesVersion: 1.15.0
 appVersion: 5.7

--- a/repository/mysql/operator/params.yaml
+++ b/repository/mysql/operator/params.yaml
@@ -11,3 +11,6 @@ parameters:
     default: "backup.sql"
     description: "Filename to restore the db from"
     trigger: restore
+  - name: STORAGE
+    default: 1Gi
+    description: "Size of volume to store MySQL data"

--- a/repository/mysql/operator/templates/backup-pv.yaml
+++ b/repository/mysql/operator/templates/backup-pv.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Name }}-backup-pv
+  namespace: {{ .Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/repository/mysql/operator/templates/backup.yaml
+++ b/repository/mysql/operator/templates/backup.yaml
@@ -1,8 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  namespace: default
   name: {{ .PlanName }}-job
+  namespace: {{ .Namespace }}
 spec:
   template:
     metadata:
@@ -10,13 +10,13 @@ spec:
     spec:
       restartPolicy: OnFailure
       containers:
-      - name: bb
+      - name: {{ .PlanName }}
         image: mysql:5.7
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh
         - -c
-        - "mysqldump -u root -h mysql -p{{ .Params.PASSWORD }} kudo > /backups/{{ .Params.BACKUP_FILE }}"
+        - "mysqldump -u root -h {{ .Name }}-svc -p{{ .Params.PASSWORD }} kudo > /backups/{{ .Params.BACKUP_FILE }}"
         volumeMounts:
         - name: backup-pv
           mountPath: /backups

--- a/repository/mysql/operator/templates/init.yaml
+++ b/repository/mysql/operator/templates/init.yaml
@@ -1,8 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  namespace: default
   name: {{ .PlanName }}-job
+  namespace: {{ .Namespace }}
 spec:
   template:
     metadata:
@@ -16,4 +16,4 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mysql -u root -h mysql -p{{ .Params.PASSWORD }} -e \"CREATE TABLE example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );\" kudo "
+        - "mysql -u root -h {{ .Name }}-svc -p{{ .Params.PASSWORD }} -e \"CREATE TABLE example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );\" kudo "

--- a/repository/mysql/operator/templates/mysql.yaml
+++ b/repository/mysql/operator/templates/mysql.yaml
@@ -1,39 +1,42 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mysql
+  name: {{ .Name }}-svc
+  namespace: {{ .Namespace }}
 spec:
   ports:
-  - port: 3306
+    - port: 3306
   selector:
-    app: mysql
+    app: {{ .Name }}
   clusterIP: None
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: mysql-pv
+  name: {{ .Name }}-pv
+  namespace: {{ .Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Params.STORAGE }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mysql
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
 spec:
   selector:
     matchLabels:
-      app: mysql
+      app: {{ .Name }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: mysql
+        app: {{ .Name }}
       name: mysql
     spec:
       containers:
@@ -49,9 +52,9 @@ spec:
           value: kudo
         ports:
         - containerPort: 3306
-          name: mysql
+          name: mysql-port
         volumeMounts:
-        - name: mysql-persistent-storage
+        - name: {{ .Name }}-persistent-storage
           mountPath: /var/lib/mysql
         livenessProbe:
           exec:
@@ -67,6 +70,6 @@ spec:
           periodSeconds: 2
           timeoutSeconds: 1
       volumes:
-      - name: mysql-persistent-storage
+      - name: {{ .Name }}-persistent-storage
         persistentVolumeClaim:
-          claimName: mysql-pv
+          claimName: {{ .Name }}-pv

--- a/repository/mysql/operator/templates/restore.yaml
+++ b/repository/mysql/operator/templates/restore.yaml
@@ -1,8 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  namespace: default
   name: {{ .PlanName }}-job
+  namespace: {{ .Namespace }}
 spec:
   template:
     metadata:
@@ -16,7 +16,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mysql -u root -h mysql -p{{ .Params.PASSWORD }} --database=kudo < /backups/{{ .Params.BACKUP_FILE }}"
+        - "mysql -u root -h {{ .Name }}-svc -p{{ .Params.PASSWORD }} --database=kudo < /backups/{{ .Params.RESTORE_FILE }}"
         volumeMounts:
         - name: backup-pv
           mountPath: /backups


### PR DESCRIPTION
Update the various templates to allow deployment of multiple instances of MySQL.

Bump the OV to 0.3.0.

Fixes #183 