### PR TITLE
kafka: Remove logo from all but README.md.

### DIFF
--- a/repository/kafka/docs/latest/README.md
+++ b/repository/kafka/docs/latest/README.md
@@ -1,3 +1,5 @@
+![kudo-kafka](./resources/images/kudo-kafka.png)
+
 ## KUDO Kafka latest
 
 - [Installation](./install.md)

--- a/repository/kafka/docs/latest/concepts.md
+++ b/repository/kafka/docs/latest/concepts.md
@@ -1,5 +1,3 @@
-![kudo-kafka](./resources/images/kudo-kafka.png)
-
 # KUDO Kafka Concepts
 
 KUDO Kafka is a Kubernetes operator built on top of [KUDO](kudo.dev) and requires KUDO

--- a/repository/kafka/docs/latest/external-access.md
+++ b/repository/kafka/docs/latest/external-access.md
@@ -1,6 +1,3 @@
-![kudo-kafka](./resources/images/kudo-kafka.png)
-
-
 # KUDO Kafka Access
 
 Kafka is a fully distributed messaging system as it persists, receives and sends records on different brokers.

--- a/repository/kafka/docs/latest/limitations.md
+++ b/repository/kafka/docs/latest/limitations.md
@@ -1,5 +1,3 @@
-
-
 # Limitations
 
 Below is a list of parameters that can only be configured during bootstrap time.

--- a/repository/kafka/docs/latest/production.md
+++ b/repository/kafka/docs/latest/production.md
@@ -1,8 +1,4 @@
-![kudo-kafka](./resources/images/kudo-kafka.png)
-
 # Running KUDO Kafka in production
-
-
 
 ## Checklist
 

--- a/repository/kafka/docs/latest/update.md
+++ b/repository/kafka/docs/latest/update.md
@@ -1,5 +1,3 @@
-
-
 # Update the Kafka cluster
 
 #### Tuning the configuration 

--- a/repository/kafka/docs/latest/upgrade.md
+++ b/repository/kafka/docs/latest/upgrade.md
@@ -1,7 +1,5 @@
 # Upgrading the KUDO Kafka Operator
 
-
-
 KUDO Kafka upgrades work by linking the Kafka cluster `Instance` object to the correct `operatorVersion` object.
 
 We can have multiple operator versions in the same Kubernetes cluster. 


### PR DESCRIPTION
It seems to interfere with the detection of top-level header title by
vuepress (which renders kudo.dev) cauising the navigation bar to look
ugly.

This is a quick workaround. Hopefully we can restore it once the
embedding of docs on kudo site is implemented in a nice way using
something like GatsbyJS.