### PR TITLE
kafka: add params for node exporter resources

### DIFF
--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -17,17 +17,29 @@ parameters:
     default: "3"
     displayName: "Broker Count"
   - name: BROKER_CPUS
-    description: "CPUs (request) for the Kafka Broker pods. spec.containers[].resources.requests.cpu"
+    description: "CPUs (request) for the Kafka Broker container"
     default: "500m"
   - name: BROKER_CPUS_LIMIT
-    description: "CPUs (limit) for the Kafka Broker pods. spec.containers[].resources.limits.cpu"
+    description: "CPUs (limit) for the Kafka Broker container"
     default: "2000m"
   - name: BROKER_MEM
-    description: "Memory (request) for the Kafka Broker pods. spec.containers[].resources.requests.memory"
+    description: "Memory (request) for the Kafka Broker container"
     default: "2048Mi"
   - name: BROKER_MEM_LIMIT
-    description: "Memory (limit) for the Kafka Broker pods. spec.containers[].resources.limits.memory"
+    description: "Memory (limit) for the Kafka Broker container"
     default: "4096Mi"
+  - name: NE_MEM
+    default: "20Mi"
+    description: "Memory (request) for the Kafka node exporter sidecar"
+  - name: NE_CPUS
+    default: "100m"
+    description: "CPUs (request) for the Kafka node exporter sidecar"
+  - name: NE_MEM_LIMIT
+    default: "512Mi"
+    description: "Memory (limit) for the Kafka node exporter sidecar"
+  - name: NE_CPUS_LIMIT
+    default: "1500m"
+    description: "CPUs (limit) for the Kafka node exporter sidecar"
   - name: BROKER_PORT
     description: "Port brokers run on"
     default: "9093"

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -30,11 +30,11 @@ spec:
           image: quay.io/prometheus/node-exporter:v0.18.1
           resources:
             requests:
-              memory: 20Mi
-              cpu: 0.1
+              memory: {{ .Params.NE_MEM }}
+              cpu: {{ .Params.NE_CPUS }}
             limits:
-              memory: 50Mi
-              cpu: 0.2
+              memory: {{ .Params.NE_MEM_LIMIT }}
+              cpu: {{ .Params.NE_CPUS_LIMIT }}
           ports:
             - containerPort: {{ .Params.KAFKA_NODE_EXPORTER_PORT }}
               name: ne-metrics

--- a/repository/kafka/tests/kafka-upgrade-test/00-install.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/00-install.yaml
@@ -12,3 +12,5 @@ spec:
     NODE_COUNT: "1"
     MEMORY: "256Mi"
     CPUS: "0.3"
+    NE_MEM: "10Mi"
+    NE_CPUS: "50m"

--- a/repository/kafka/tests/kafka-upgrade-test/01-assert.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/01-assert.yaml
@@ -17,8 +17,8 @@ spec:
       - name: kafka-node-exporter
         resources:
           requests:
-            memory: "20Mi"
-            cpu: "100m"
+            memory: "10Mi"
+            cpu: "50m"
       - name: k8skafka
         resources:
           requests:

--- a/repository/kafka/tests/kafka-upgrade-test/01-install.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/01-install.yaml
@@ -13,3 +13,5 @@ spec:
     BROKER_MEM: "300Mi"
     BROKER_CPUS: "300m"
     ZOOKEEPER_URI: "zk-zookeeper-0.zk-hs:2181"
+    NE_MEM: "10Mi"
+    NE_CPUS: "50m"

--- a/repository/kafka/tests/kafka-upgrade-test/02-assert.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/02-assert.yaml
@@ -17,8 +17,8 @@ spec:
       - name: kafka-node-exporter
         resources:
           requests:
-            memory: "20Mi"
-            cpu: "100m"
+            memory: "10Mi"
+            cpu: "50m"
       - name: k8skafka
         resources:
           requests:

--- a/repository/kafka/tests/kafka-upgrade-test/02-resize.yaml
+++ b/repository/kafka/tests/kafka-upgrade-test/02-resize.yaml
@@ -11,3 +11,5 @@ spec:
   parameters:
     BROKER_MEM: "400Mi"
     BROKER_CPUS: "300m"
+    NE_MEM: "10Mi"
+    NE_CPUS: "50m"


### PR DESCRIPTION
During a heavy workload test, we discovered that for node exporter sidecar the `CPUThrottlingHigh`alert was being triggered. 

This PR makes sure that resources used by the sidecar can be adjusted as per Kafka workload 

Signed-off-by: Zain Malik <zmalikshxil@gmail.com>