### PR TITLE
Upgrade Spark from 2.4.4 to 2.4.5, upgrade Spark Operator from 1.0.1 to 1.1.0

### DIFF
--- a/repository/spark/README.md
+++ b/repository/spark/README.md
@@ -10,6 +10,6 @@ The documentation is available in [docs/2.4.4-0.2.0](./docs/2.4.4-0.2.0) folder.
 
 | KUDO Spark version | Apache Spark version | Operator version        | Minimum KUDO Version | Status |
 | ------------------ | -------------------- | ----------------------- | -------------------- | ------ |
-| latest             | 2.4.4 (Hadoop 2.9.2) | v1beta2-1.0.1           | 0.10.1               | beta   |
+| latest             | 2.4.5 (Hadoop 2.9.2) | v1beta2-1.1.0           | 0.10.1               | beta   |
 | 2.4.4-0.2.0        | 2.4.4 (Hadoop 2.9.2) | v1beta2-1.0.1           | 0.10.1               | beta   |
 | beta1              | 2.4.3 (Hadoop 2.9.2) | v1beta2-1.0.1           | 0.8.0                | beta   |

--- a/repository/spark/docs/latest/resources/monitoring/spark-application-with-metrics.yaml
+++ b/repository/spark/docs/latest/resources/monitoring/spark-application-with-metrics.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: mesosphere/spark:spark-2.4.4-hadoop-2.9-k8s
+  image: mesosphere/spark:spark-2.4.5-hadoop-2.9-k8s
   imagePullPolicy: Always
   mainClass: MockTaskRunner
   mainApplicationFile: "https://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.4.0-20190325.jar"
@@ -15,7 +15,7 @@ spec:
   sparkConf:
     "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
     "spark.scheduler.minRegisteredResourcesRatio": "1.0"
-  sparkVersion: "2.4.4"
+  sparkVersion: "2.4.5"
   restartPolicy:
     type: Never
   driver:
@@ -30,7 +30,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5
       metrics-exposed: "true"
   monitoring:
     exposeDriverMetrics: true

--- a/repository/spark/docs/latest/resources/spark-pi.yaml
+++ b/repository/spark/docs/latest/resources/spark-pi.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "mesosphere/spark:spark-2.4.4-hadoop-2.9-k8s"
+  image: "mesosphere/spark:spark-2.4.5-hadoop-2.9-k8s"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar"
   arguments:
     - "150000"
   sparkConf:
@@ -21,11 +21,11 @@ spec:
     cores: 1
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5
     serviceAccount: spark-driver
   executor:
     cores: 1
     instances: 4
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5

--- a/repository/spark/docs/latest/submission.md
+++ b/repository/spark/docs/latest/submission.md
@@ -18,29 +18,29 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "mesosphere/spark:spark-2.4.4-hadoop-2.9-k8s"
+  image: "mesosphere/spark:spark-2.4.5-hadoop-2.9-k8s"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar"
   arguments:
     - "150000"
   sparkConf:
     "spark.ui.port": "4041"
-  sparkVersion: "2.4.4"
+  sparkVersion: "2.4.5"
   restartPolicy:
     type: Never
   driver:
     cores: 1
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5
     serviceAccount: spark-driver
   executor:
     cores: 1
     instances: 2
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5
 ```
 
 Basically, all the Spark application configuration is placed under `spec` section. Here you can specify Spark related configuration properties, such as number of executors, number of cores for drivers/executors, amount of memory, etc. There is also a `sparkConf` section, where you can place configuration parameters in the form of key-value pairs. In this example, we override the default `spark.ui.port` with a custom value.

--- a/repository/spark/docs/latest/versions.md
+++ b/repository/spark/docs/latest/versions.md
@@ -1,8 +1,8 @@
 # Versions
 
 ## Component Versions
-* Apache Spark 2.4.4 built with Hadoop 2.9.2 and Scala 2.11
-* Spark Operator v1beta2-1.0.1
+* Apache Spark 2.4.5 built with Hadoop 2.9.2 and Scala 2.11
+* Spark Operator v1beta2-1.1.0
 * OpenJDK 8
 * Prometheus Java agent 0.11.0
 

--- a/repository/spark/operator/operator.yaml
+++ b/repository/spark/operator/operator.yaml
@@ -1,5 +1,5 @@
 apiVersion: kudo.dev/v1beta1
-appVersion: 2.4.4
+appVersion: 2.4.5
 kubernetesVersion: 1.15.0
 kudoVersion: 0.10.1
 maintainers:

--- a/repository/spark/operator/params.yaml
+++ b/repository/spark/operator/params.yaml
@@ -34,7 +34,7 @@ parameters:
 
   - name: operatorVersion
     description: "Operator Docker image version (tag)"
-    default: 2.4.4-0.2.0
+    default: 2.4.5-0.2.0
     displayName: "Operator Docker image version (tag)"
 
   - name: imagePullPolicy


### PR DESCRIPTION
This PR updates the docs and configuration the latest stable Apache Spark release and the corresponding Spark Operator release supporting this version.