### PR TITLE
Add `delegationTokenSecret` parameter to support Hadoop Delegation tokens

### DIFF
--- a/repository/spark/operator/params.yaml
+++ b/repository/spark/operator/params.yaml
@@ -119,6 +119,11 @@ parameters:
     default: ""
     displayName: "Name of a Secret with Spark History Server configuration file"
 
+  - name: delegationTokenSecret
+    description: "Name of a Secret with Hadoop Delegation Token. The secret should be in the same namespace as the Operator."
+    default: ""
+    displayName: "Name of a Secret with Hadoop Delegation Token"
+
   ## Miscellaneous
   - name: sparkJobNamespace
     description: "Namespace for Spark Applications. Defaults to Operator namespace"

--- a/repository/spark/operator/templates/spark-history-server-deployment.yaml
+++ b/repository/spark/operator/templates/spark-history-server-deployment.yaml
@@ -37,27 +37,53 @@ spec:
         env:
         - name: SPARK_NO_DAEMONIZE
           value: "true"
+        {{- if .Params.delegationTokenSecret }}
+        - name: HADOOP_TOKEN_FILE_LOCATION
+          value: "/mnt/secrets/hadoop.token"
+        {{- end }}
         - name: SPARK_HISTORY_OPTS
-          value: "{{ .Params.historyServerOpts }} -Dspark.history.fs.logDirectory={{ .Params.historyServerFsLogDirectory }} -Dspark.history.fs.cleaner.enabled={{ .Params.historyServerCleanerEnabled }} -Dspark.history.fs.cleaner.interval={{ .Params.historyServerCleanerInterval }} -Dspark.history.fs.cleaner.maxAge={{ .Params.historyServerCleanerMaxAge }}"
+          value: >-
+           {{ .Params.historyServerOpts }}
+           -Dspark.history.fs.logDirectory={{ .Params.historyServerFsLogDirectory }}
+           -Dspark.history.fs.cleaner.enabled={{ .Params.historyServerCleanerEnabled }}
+           -Dspark.history.fs.cleaner.interval={{ .Params.historyServerCleanerInterval }}
+           -Dspark.history.fs.cleaner.maxAge={{ .Params.historyServerCleanerMaxAge }}
         ports:
         - containerPort: 18080
           name: "history-server"
+        {{- if or (.Params.historyServerSparkConfSecret) (.Params.delegationTokenSecret) (.Params.historyServerPVCName) }}
         volumeMounts:
+          {{- if .Params.historyServerSparkConfSecret }}
           - name: spark-conf
             mountPath: "/opt/spark/conf"
             readOnly: true
+          {{- end }}
+          {{- if .Params.delegationTokenSecret }}
+          - name: hadoop-token
+            mountPath: /mnt/secrets
+            readOnly: true
+          {{- end }}
           {{- if .Params.historyServerPVCName }}
           - mountPath: "{{ .Params.historyServerFsLogDirectory }}"
             name: history-server-storage
           {{- end }}
+        {{- end }}
+      {{- if or (.Params.historyServerSparkConfSecret) (.Params.delegationTokenSecret) (.Params.historyServerPVCName) }}
       volumes:
+        {{- if .Params.historyServerSparkConfSecret }}
         - name: spark-conf
           secret:
             secretName: {{ .Params.historyServerSparkConfSecret }}
-            optional: true
+        {{- end }}
+        {{- if .Params.delegationTokenSecret }}
+        - name: hadoop-token
+          secret:
+            secretName: hadoop-token
+        {{- end }}
         {{- if .Params.historyServerPVCName }}
         - name: history-server-storage
           persistentVolumeClaim:
             claimName: {{ .Params.historyServerPVCName }}
         {{- end }}
+      {{- end}}
 {{- end }}


### PR DESCRIPTION
This PR introduces a new parameter `delegationTokenSecret` to allow mounting Hadoop Delegation token to Spark History Server for accessing secured HDFS.  

Signed-off-by: Alex Lembiewski <alembiyeuski.c@d2iq.com>