### PR TITLE
kafka: Add Kafka Connect to operator

### DIFF
--- a/repository/kafka/docs/latest/kafka-connect.md
+++ b/repository/kafka/docs/latest/kafka-connect.md
@@ -1,0 +1,323 @@
+# Kafka Connect
+
+## Overview
+
+KUDO Kafka operator comes with builtin integration of [Kafka Connect](https://kafka.apache.org/documentation/#connect).
+
+Kafka Connect is a tool for scalably and reliably streaming data between Apache Kafka and other systems. It provides a [REST API](https://kafka.apache.org/documentation/#connect_rest) to configure and interact connectors.
+
+Kafka Connect integration is disabled by default.
+
+This guide shows how to stream data from a Cassandra instance to a MySQL instance using the integration provided by the operator.
+
+## Pre-conditions
+
+The following are necessary for this runbook:
+- One running Cassandra cluster.
+- One running MySQL server.
+
+## Steps
+
+### Preparation
+
+### 1. Set the shell variables
+
+The examples below assume the following shell variables. With this assumptions met, you should be able to copy-paste the commands easily.
+
+```bash
+kafka_namespace_name=kafka-demo
+kafka_instance_name=kafka
+```
+
+You also need the following:
+
+:arrow_right: **Cassandra instance node list**
+
+:warning: This runbook assumes that the Cassandra instance has transport encryption (TLS) and authorization disabled.
+
+**If the Cassandra instance is a [KUDO Cassandra](https://github.com/kudobuilder/operators/tree/master/repository/cassandra/3.11) instance running in the same kubernetes
+cluster:**
+
+You can generate the node list using the following commands:
+```bash
+cassandra_instance_name=cassandra
+cassandra_namespace_name=cassandra-demo
+cassandra_port=$(kubectl get svc ${cassandra_instance_name}-svc -n $cassandra_namespace_name \
+  --template='{{ range .spec.ports }}{{if eq .name "native-transport" }}{{ .port }}{{ end }}{{ end }}')
+cassandra_node_list=$(kubectl get pods -l app=cassandra,cassandra=cassandra,kudo.dev/instance=$cassandra_instance_name -n $cassandra_namespace_name \
+  --template="{{ range .items }}{{ .spec.hostname }}.{{ .spec.subdomain }}.{{ .metadata.namespace }}.svc.cluster.local{{ \"\\n\" }}{{end}}" \
+  | head -n 3 | paste -d, -s)
+echo $cassandra_node_list 
+```
+
+Example output:
+```
+cassandra-node-0.cassandra-svc.cassandra-demo.svc.cluster.local,cassandra-node-1.cassandra-svc.cassandra-demo.svc.cluster.local,cassandra-node-2.cassandra-svc.cassandra-demo.svc.cluster.local
+```
+
+**Otherwise:**
+
+Please refer to its documentation about how to retrieve a list of cassandra nodes.
+These need to be reachable from the KUDO Kafka instance.
+
+```bash
+cassandra_nodes_list=cassandra-node-1.example.com,cassandra-node-2.example.com
+```
+
+:arrow_right: **MySQL instance hostname, port, user credentinals and database name**
+
+**If the MySQL instance is a [KUDO MySQL](https://github.com/kudobuilder/operators/tree/master/repository/mysql) instance running in the same kubernetes
+cluster:**
+
+You can generate the required MySQL variables using the following commands:
+```bash
+mysql_instance_name=mysql
+mysql_namespace_name=mysql-demo
+mysql_port=$(kubectl get svc ${mysql_instance_name} -n $mysql_namespace_name \
+  --template='{{ range .spec.ports }}{{ .port }}{{ end }}')
+mysql_hostname=$mysql_instance_name.$mysql_namespace_name.svc.cluster.local
+mysql_user=demo
+mysql_password=demo
+mysql_database=demo
+mysql_root_password=$(kubectl get pods -l app=mysql,kudo.dev/instance=$mysql_instance_name -n $mysql_namespace_name \
+  --template='{{ range .items }}{{ range .spec.containers }}{{ if eq .name "mysql" }}{{ range .env }}{{ if eq .name "MYSQL_ROOT_PASSWORD" }}{{ .value }}{{ "\n" }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}' \
+  | head -n 1 )
+mysql_pod=$(kubectl get pods -l app=mysql,kudo.dev/instance=$mysql_instance_name -n $mysql_namespace_name \
+  --template='{{ range .items }}{{ .metadata.name }}{{ "\n" }}{{ end }}' \
+  | head -n 1 )
+kubectl exec -n $mysql_namespace_name -it $mysql_pod -- mysql -p$mysql_root_password --execute="CREATE DATABASE demo; GRANT ALL PRIVILEGES ON demo.* TO 'demo'@'%' IDENTIFIED BY 'demo'; FLUSH PRIVILEGES;"
+echo $mysql_hostname $mysql_port
+echo $mysql_user $mysql_password
+echo $mysql_database
+```
+:warning: The commands also create a user `demo` with full access to a new database `demo`.
+
+Example output:
+```
+mysql.mysql-demo.svc.cluster.local 3306
+demo demo
+demo
+```
+
+**Otherwise:**
+
+Please refer to its documentation about how to retrieve the hostname and port.
+The hostname and port need to be reachable from the KUDO Kafka instance. Also the user credintials provided must be able to create tables, read and write data in the database.
+
+```bash
+mysql_hostname=mysql.example.com
+mysql_port=3306
+mysql_user=demo
+mysql_password=demo
+mysql_database=demo
+```
+
+### 2. Create a new schema with table in the Cassandra instance
+
+Create a schema `demo` and a table `users`. Run the following CQL query in `cqlsh`:
+
+```sql
+CREATE SCHEMA demo WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+USE demo;
+CREATE TABLE users ( userid int, firstname varchar, lastname varchar, email varchar,
+ created_date timestamp, PRIMARY KEY (userid));
+```
+
+:information_source: If the Cassandra instance is a KUDO Cassandra instance running in the same kubernetes
+cluster, use the following commands to access cqlsh:
+
+```bash
+cassandra_pod=$(kubectl get pods -l app=cassandra,cassandra=cassandra,kudo.dev/instance=$cassandra_instance_name -n $cassandra_namespace_name \
+  --template='{{ range .items }}{{ .metadata.name }}{{ "\n" }}{{ end }}' \
+  | head -n 1 )
+kubectl exec -n $cassandra_namespace_name -it -c cassandra $cassandra_pod -- bash -c "CQLSH_PORT=$cassandra_port CQLSH_HOST=\$(hostname -f) cqlsh"
+```
+
+## Setup Kafka Connect
+
+### Connectors Configuration
+
+KUDO Kafka Connect accepts a Config Map with an entry of `config.json`. This configuration file contains the bootstrap connectors list describing their respective external asset list with and their configuration.
+
+```json
+{
+  "<connector#1-name>": {
+    "resources": [
+      "<link to asset#1>",
+      "<link to asset#2>",
+      ...
+    ],
+    "config": <configuration of connector#1>
+  },
+  ...
+}
+```
+
+:information_source: The operator also accepts configuration in YAML format.
+
+:information_source: The operator uses `p7zip` utility to extract archive assets. For the list of supported archive formats check its [documentation](https://packages.debian.org/buster/p7zip-full).
+
+
+#### Configuring Cassandra Source and MySQL Sink connectors
+
+
+```bash
+cat <<EOT > config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectorsconfig
+  namespace: ${kafka_namespace_name}
+data:
+  config.json: |
+    {
+      "mysql-sink-connector": {
+        "resources": [
+            "https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-jdbc/versions/5.4.0/confluentinc-kafka-connect-jdbc-5.4.0.zip",
+            "https://cdn.mysql.com//Downloads/Connector-J/mysql-connector-java-8.0.19.zip"
+        ],
+        "config": {
+            "name": "jdbc_dest_mysql_users",
+            "config": {
+                "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+                "tasks.max": "1",
+                "topics": "demo_topic",
+                "connection.url": "jdbc:mysql://${mysql_hostname}:${mysql_port}/${mysql_database}?user=${mysql_user}&password=${mysql_password}",
+                "auto.create": "true",
+                "name": "jdbc_dest_mysql_users"
+            }
+        }
+      },
+      "cassandra-source-connector": {
+        "resources": [
+            "https://github.com/lensesio/stream-reactor/releases/download/1.2.3/kafka-connect-cassandra-1.2.3-2.1.0-all.tar.gz"
+        ],
+        "config": {
+            "name": "cassandra_source_users",
+            "config": {
+                "tasks.max": "1",
+                "connector.class": "com.datamountaineer.streamreactor.connect.cassandra.source.CassandraSourceConnector",
+                "connect.cassandra.contact.points": "${cassandra_node_list}",
+                "connect.cassandra.port": ${cassandra_port},
+                "connect.cassandra.consistency.level": "LOCAL_ONE",
+                "connect.cassandra.key.space": "demo",
+                "connect.cassandra.import.mode": "incremental",
+                "connect.cassandra.kcql": "INSERT INTO demo_topic SELECT * FROM users PK created_date INCREMENTALMODE=TIMESTAMP",
+                "connect.cassandra.import.poll.interval": 5000
+            }
+        }
+      }
+    }
+EOT
+kubectl apply -f config.yaml
+```
+
+
+### Update instance to start Kafka Connect
+
+Run the following command to start Kafka Connect alongside the KUDO Kafka instance:
+
+```sh
+kubectl kudo update --instance=$kafka_instance_name \
+  --namespace=$kafka_namespace_name \
+  -p KAFKA_CONNECT_ENABLED=true \
+  -p KAFKA_CONNECT_CONNECTORS_CM=connectorsconfig
+```
+
+### Insert dummy data in the Cassandra table
+
+Execute CQL insert statements in `cqlsh` to add data to the `users` table.
+
+:bulb: To generate CQL insert statements containing random data use the following commands:
+
+```bash
+ID="${ID:-1}";query=""
+for ((i = $ID ; i <= $ID+5 ; i++))
+do
+  user=$(http https://randomuser.me/api/)
+  first=$(echo $user | jq -r '.results[].name.first')
+  last=$(echo $user | jq -r '.results[].name.last')
+  first=$(echo $user | jq -r '.results[].name.first')
+  email=$(echo $user | jq -r '.results[].email')
+  query="$query\nINSERT INTO users (userid, firstname, lastname, email, created_date) VALUES ( $i, '$first', '$last', '$email', toTimestamp(now()));"
+done
+ID=$i
+printf "$query\n"
+```
+
+Run the following CQL commands to check for the inserted rows in `users` table:
+
+```sql
+USE demo;
+SELECT * FROM users;
+```
+
+Example output:
+
+```sql
+ userid | created_date                    | email                        | firstname | lastname
+--------+---------------------------------+------------------------------+-----------+----------
+      5 | 2020-02-17 23:58:30.683000+0000 |         swrn.prs@example.com |    George |    Brown
+      1 | 2020-02-17 23:58:30.569000+0000 |     jaime.torres@example.com |     Jaime |   Torres
+      2 | 2020-02-17 23:58:30.587000+0000 |    gladys.morris@example.com |    Gladys |   Morris
+      4 | 2020-02-17 23:58:30.670000+0000 |    marina.crespo@example.com |    Marina |   Crespo
+      6 | 2020-02-17 23:58:30.690000+0000 | matilda.anderson@example.com |   Matilda | Anderson
+      3 | 2020-02-17 23:58:30.638000+0000 |      enzo.novaes@example.com |      Enzo |   Novaes
+```
+
+
+### Check MySQL database for new data
+
+Kafka Connect will sync data from the Cassandra `users` table into MySQL. A new table `demo_topic` will be created by Kafka Conenct which be used to insert data from the `users` table of Cassandra. To check for new data run the following SQL statements:
+
+```sql
+USE demo;
+SHOW tables;
+SELECT * FROM demo_topic;
+```
+
+Example output:
+
+```sql
+mysql> use demo;
+
+Database changed
+mysql> show tables;
++----------------+
+| Tables_in_demo |
++----------------+
+| demo_topic     |
++----------------+
+1 row in set (0.00 sec)
+
+mysql> select * from demo_topic;
++-----------+-------------------------+--------+------------------------------+----------+
+| firstname | created_date            | userid | email                        | lastname |
++-----------+-------------------------+--------+------------------------------+----------+
+| George    | 2020-02-17 23:58:30.683 |      5 | swrn.prs@example.com         | Brown    |
+| Jaime     | 2020-02-17 23:58:30.569 |      1 | jaime.torres@example.com     | Torres   |
+| Gladys    | 2020-02-17 23:58:30.587 |      2 | gladys.morris@example.com    | Morris   |
+| Marina    | 2020-02-17 23:58:30.670 |      4 | marina.crespo@example.com    | Crespo   |
+| Matilda   | 2020-02-17 23:58:30.690 |      6 | matilda.anderson@example.com | Anderson |
+| Enzo      | 2020-02-17 23:58:30.638 |      3 | enzo.novaes@example.com      | Novaes   |
++-----------+-------------------------+--------+------------------------------+----------+
+6 rows in set (0.00 sec)
+```
+
+## Disable Kafka Connect
+
+To disable Kafka Connect, scale the
+pod count to 0, using the following command:
+
+```sh
+kubectl kudo update --instance=$kafka_instance_name \
+  --namespace=$kafka_namespace_name \
+  -p KAFKA_CONNECT_REPLICA_COUNT=0
+``` 
+
+
+## Limitations
+
+Currently Kafka Connect works with Kafka protocol `PLAINTEXT` only. It will not work if Kerberos and or TLS is
+enabled in the Kafka instance. Future releases of KUDO Kafka will
+address this limitation through a Kafka Connect operator.

--- a/repository/kafka/docs/latest/kafka-connect.md
+++ b/repository/kafka/docs/latest/kafka-connect.md
@@ -132,13 +132,13 @@ $ kubectl kudo update --instance=kafka \
 
 ## Disable Kafka Connect
 
-To disable Kafka Connect, scale the
-pod count to 0, using the following command:
+To disable Kafka Connect, update the
+instance with `KAFKA_CONNECT_ENABLED` set to `false`, using the following command:
 
 ```bash
 $ kubectl kudo update --instance=$kafka_instance_name \
   --namespace=$kafka_namespace_name \
-  -p KAFKA_CONNECT_REPLICA_COUNT=0
+  -p KAFKA_CONNECT_ENABLED=false
 ``` 
 
 ## Limitations

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -38,15 +38,17 @@ tasks:
       resources:
         - service.yaml
   - name: kafka-connect
-    kind: Apply
+    kind: Toggle
     spec:
+      parameter: KAFKA_CONNECT_ENABLED
       resources:
         - kafka-connect-config.yaml
         - kafka-connect-service.yaml
         - kafka-connect.yaml
   - name: kafka-connect-setup
-    kind: Apply
+    kind: Toggle
     spec:
+      parameter: KAFKA_CONNECT_ENABLED
       resources:
         - kafka-connect-setup.yaml
   - name: generate-tls-certificates

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -37,6 +37,18 @@ tasks:
     spec:
       resources:
         - service.yaml
+  - name: kafka-connect
+    kind: Apply
+    spec:
+      resources:
+        - kafka-connect-config.yaml
+        - kafka-connect-service.yaml
+        - kafka-connect.yaml
+  - name: kafka-connect-setup
+    kind: Apply
+    spec:
+      resources:
+        - kafka-connect-setup.yaml
   - name: generate-tls-certificates
     kind: Pipe
     spec:
@@ -141,6 +153,18 @@ plans:
           - name: deploy
             tasks:
               - mirrormaker
+  kafka-connect:
+    strategy: serial
+    phases:
+      - name: deploy-kafka-connect
+        strategy: serial
+        steps:
+          - name: deploy
+            tasks:
+              - kafka-connect
+          - name: setup
+            tasks:
+              - kafka-connect-setup
   external-access:
     strategy: serial
     phases:

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -880,20 +880,33 @@ parameters:
     description: "Memory (limit) for the Kafka Connect pods. spec.containers[].resources.limits.memory"
     default: "2048Mi"
     trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_CUSTOM_CM
+    displayName: "Kafka Connect custom configuration Config Map"
+    description: "Kafka Connect custom configuration Config Map"
+    required: false
+    trigger: "kafka-connect"
   - name: KAFKA_CONNECT_CONNECTORS_CM
     displayName: "Connectors configuration Config Map"
     description: "The configuration used by the Connect to bootstrap itself with the specified connectors."
     required: false
     trigger: "kafka-connect"
   - name: KAFKA_CONNECT_REST_PORT
+    displayName: "Kafka Connect port"
+    description: "Port for the REST API server to listen to."
     default: 8083
     trigger: "kafka-connect"
-  - name: KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE
-    default: "true"
+  - name: KAFKA_CONNECT_KEY_CONVERTER
+    displayName: "Kafka Connect key converter"
+    description: "The key converters specify the format of data in Kafka message key and how to translate it into Connect data"
+    default: "org.apache.kafka.connect.json.JsonConverter"
     trigger: "kafka-connect"
-  - name: KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE
-    default: "true"
+  - name: KAFKA_CONNECT_VALUE_CONVERTER
+    displayName: "Kafka Connect value converter"
+    description: "The value converter specify the format of data in Kafka message value and how to translate it into Connect data"
+    default: "org.apache.kafka.connect.json.JsonConverter"
     trigger: "kafka-connect"
   - name: KAFKA_CONNECT_OFFSET_FLUSH_INTERVAL_MS
+    displayName: "Kafka Connect offset flush interval in milliseconds"
+    description: "Kafka Connect topic offset flush interval in milliseconds"
     default: 10000
     trigger: "kafka-connect"

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -858,3 +858,42 @@ parameters:
     description: "Memory (limit) for the Mirror Maker pods. spec.containers[].resources.limits.memory"
     default: "512Mi"
     trigger: "mirrormaker"
+  - name: KAFKA_CONNECT_ENABLED
+    default: "false"
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_REPLICA_COUNT
+    default: "1"
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_CPUS
+    description: "CPUs (request) for the Kafka Connect pods. spec.containers[].resources.requests.cpu"
+    default: "500m"
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_CPUS_LIMIT
+    description: "CPUs (limit) for the Kafka Connect pods. spec.containers[].resources.limits.cpu"
+    default: "500m"
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_MEM
+    description: "Memory (request) for the Kafka Connect pods. spec.containers[].resources.requests.memory"
+    default: "2048Mi"
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_MEM_LIMIT
+    description: "Memory (limit) for the Kafka Connect pods. spec.containers[].resources.limits.memory"
+    default: "2048Mi"
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_CONNECTORS_CM
+    displayName: "Connectors configuration Config Map"
+    description: "The configuration used by the Connect to bootstrap itself with the specified connectors."
+    required: false
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_REST_PORT
+    default: 8083
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE
+    default: "true"
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE
+    default: "true"
+    trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_OFFSET_FLUSH_INTERVAL_MS
+    default: 10000
+    trigger: "kafka-connect"

--- a/repository/kafka/operator/templates/kafka-connect-config.yaml
+++ b/repository/kafka/operator/templates/kafka-connect-config.yaml
@@ -18,12 +18,8 @@ data:
     
     # The converters specify the format of data in Kafka and how to translate it into Connect data. Every Connect user will
     # need to configure these based on the format they want their data in when loaded from or stored into Kafka
-    key.converter=org.apache.kafka.connect.json.JsonConverter
-    value.converter=org.apache.kafka.connect.json.JsonConverter
-    # Converter-specific settings can be passed in by prefixing the Converter's setting with the converter we want to apply
-    # it to
-    key.converter.schemas.enable={{ .Params.KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE }}
-    value.converter.schemas.enable={{ .Params.KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE }}
+    key.converter={{ .Params.KAFKA_CONNECT_KEY_CONVERTER }}
+    value.converter={{ .Params.KAFKA_CONNECT_VALUE_CONVERTER }}
     
     # Topic to use for storing offsets. This topic should have many partitions and be replicated and compacted.
     # Kafka Connect will attempt to create the topic automatically when needed, but you can always manually create
@@ -52,7 +48,7 @@ data:
     # to run this example on a single-broker cluster and so here we instead set the replication factor to 1.
     status.storage.topic={{ .Name }}-connect-status
     status.storage.replication.factor={{ if lt (int .Params.BROKER_COUNT) 3 }}{{ .Params.BROKER_COUNT }}{{ else }}3{{ end }}
-    #status.storage.partitions=25
+    #status.storage.partitions=1
     
     # Flush much faster than normal, which is useful for testing/debugging
     offset.flush.interval.ms={{ .Params.KAFKA_CONNECT_OFFSET_FLUSH_INTERVAL_MS }}
@@ -60,7 +56,7 @@ data:
     # These are provided to inform the user about the presence of the REST host and port configs 
     # Hostname & Port for the REST API to listen on. If this is set, it will bind to the interface used to listen to requests.
     #rest.host.name=
-    #rest.port=8083
+    rest.port={{ .Params.KAFKA_CONNECT_REST_PORT }}
     
     # The Hostname & Port that will be given out to other workers to connect to i.e. URLs that are routable from other servers.
     #rest.advertised.host.name=
@@ -75,4 +71,5 @@ data:
     # Examples: 
     plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/kafka/connectors,
     #plugin.path=
+    
 {{ end }}

--- a/repository/kafka/operator/templates/kafka-connect-config.yaml
+++ b/repository/kafka/operator/templates/kafka-connect-config.yaml
@@ -1,4 +1,3 @@
-{{ if eq .Params.KAFKA_CONNECT_ENABLED "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -71,5 +70,3 @@ data:
     # Examples: 
     plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/kafka/connectors,
     #plugin.path=
-    
-{{ end }}

--- a/repository/kafka/operator/templates/kafka-connect-config.yaml
+++ b/repository/kafka/operator/templates/kafka-connect-config.yaml
@@ -1,0 +1,78 @@
+{{ if eq .Params.KAFKA_CONNECT_ENABLED "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Name }}-kafka-connect-config
+  namespace: {{ .Namespace }}
+data:
+  connect-distributed.properties: |
+    # This file contains some of the configurations for the Kafka Connect distributed worker. This file is intended
+    # to be used with the examples, and some settings may differ from those used in a production system, especially
+    # the `bootstrap.servers` and those specifying replication factors.
+    
+    # A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
+    bootstrap.servers={{ if gt (int .Params.BROKER_COUNT) 0 }} {{ .Name }}-kafka-0.{{ .Name }}-svc:{{ .Params.BROKER_PORT }}{{- $root := . -}}{{ range $i, $v := untilStep 1 (int .Params.BROKER_COUNT) 1 }},{{ $root.Name }}-kafka-{{ $v }}.{{ $root.Name }}-svc:{{ $root.Params.BROKER_PORT }}{{ end }}{{ end }}
+    
+    # unique name for the cluster, used in forming the Connect cluster group. Note that this must not conflict with consumer group IDs
+    group.id={{ .Name }}-connect-cluster
+    
+    # The converters specify the format of data in Kafka and how to translate it into Connect data. Every Connect user will
+    # need to configure these based on the format they want their data in when loaded from or stored into Kafka
+    key.converter=org.apache.kafka.connect.json.JsonConverter
+    value.converter=org.apache.kafka.connect.json.JsonConverter
+    # Converter-specific settings can be passed in by prefixing the Converter's setting with the converter we want to apply
+    # it to
+    key.converter.schemas.enable={{ .Params.KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE }}
+    value.converter.schemas.enable={{ .Params.KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE }}
+    
+    # Topic to use for storing offsets. This topic should have many partitions and be replicated and compacted.
+    # Kafka Connect will attempt to create the topic automatically when needed, but you can always manually create
+    # the topic before starting Kafka Connect if a specific topic configuration is needed.
+    # Most users will want to use the built-in default replication factor of 3 or in some cases even specify a larger value.
+    # Since this means there must be at least as many brokers as the maximum replication factor used, we'd like to be able
+    # to run this example on a single-broker cluster and so here we instead set the replication factor to 1.
+    offset.storage.topic={{ .Name }}-connect-offsets
+    offset.storage.replication.factor={{ if lt (int .Params.BROKER_COUNT) 3 }}{{ .Params.BROKER_COUNT }}{{ else }}3{{ end }}
+    #offset.storage.partitions=25
+    
+    # Topic to use for storing connector and task configurations; note that this should be a single partition, highly replicated,
+    # and compacted topic. Kafka Connect will attempt to create the topic automatically when needed, but you can always manually create
+    # the topic before starting Kafka Connect if a specific topic configuration is needed.
+    # Most users will want to use the built-in default replication factor of 3 or in some cases even specify a larger value.
+    # Since this means there must be at least as many brokers as the maximum replication factor used, we'd like to be able
+    # to run this example on a single-broker cluster and so here we instead set the replication factor to 1.
+    config.storage.topic={{ .Name }}-connect-configs
+    config.storage.replication.factor={{ if lt (int .Params.BROKER_COUNT) 3 }}{{ .Params.BROKER_COUNT }}{{ else }}3{{ end }}
+    
+    # Topic to use for storing statuses. This topic can have multiple partitions and should be replicated and compacted.
+    # Kafka Connect will attempt to create the topic automatically when needed, but you can always manually create
+    # the topic before starting Kafka Connect if a specific topic configuration is needed.
+    # Most users will want to use the built-in default replication factor of 3 or in some cases even specify a larger value.
+    # Since this means there must be at least as many brokers as the maximum replication factor used, we'd like to be able
+    # to run this example on a single-broker cluster and so here we instead set the replication factor to 1.
+    status.storage.topic={{ .Name }}-connect-status
+    status.storage.replication.factor={{ if lt (int .Params.BROKER_COUNT) 3 }}{{ .Params.BROKER_COUNT }}{{ else }}3{{ end }}
+    #status.storage.partitions=25
+    
+    # Flush much faster than normal, which is useful for testing/debugging
+    offset.flush.interval.ms={{ .Params.KAFKA_CONNECT_OFFSET_FLUSH_INTERVAL_MS }}
+    
+    # These are provided to inform the user about the presence of the REST host and port configs 
+    # Hostname & Port for the REST API to listen on. If this is set, it will bind to the interface used to listen to requests.
+    #rest.host.name=
+    #rest.port=8083
+    
+    # The Hostname & Port that will be given out to other workers to connect to i.e. URLs that are routable from other servers.
+    #rest.advertised.host.name=
+    #rest.advertised.port=
+    
+    # Set to a list of filesystem paths separated by commas (,) to enable class loading isolation for plugins
+    # (connectors, converters, transformations). The list should consist of top level directories that include 
+    # any combination of: 
+    # a) directories immediately containing jars with plugins and their dependencies
+    # b) uber-jars with plugins and their dependencies
+    # c) directories immediately containing the package directory structure of classes of plugins and their dependencies
+    # Examples: 
+    plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/kafka/connectors,
+    #plugin.path=
+{{ end }}

--- a/repository/kafka/operator/templates/kafka-connect-service.yaml
+++ b/repository/kafka/operator/templates/kafka-connect-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Name }}-connect-svc
+  namespace: {{ .Namespace }}
+  {{ if eq .Params.METRICS_ENABLED "true" }}
+  labels:
+    "kudo.dev/servicemonitor": "true"
+  {{ end }}
+spec:
+  ports:
+    - port: {{ .Params.KAFKA_CONNECT_REST_PORT }}
+      name: server
+  clusterIP: None
+  selector:
+    app: kafka-connect
+    kudo.dev/instance: {{ .Name }}

--- a/repository/kafka/operator/templates/kafka-connect-setup.yaml
+++ b/repository/kafka/operator/templates/kafka-connect-setup.yaml
@@ -1,4 +1,3 @@
-{{ if eq .Params.KAFKA_CONNECT_ENABLED "true" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -55,4 +54,3 @@ spec:
           configMap:
             name: {{ .Params.KAFKA_CONNECT_CONNECTORS_CM }}
         {{ end }}
-{{ end }}

--- a/repository/kafka/operator/templates/kafka-connect-setup.yaml
+++ b/repository/kafka/operator/templates/kafka-connect-setup.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: kafka-connect-setup
-        image: shubhanilbag/kafka:2.4.0-1.2.1
+        image: shubhanilbag/kafka:2.4.0-1.3.0
         imagePullPolicy: Always
         resources:
           requests:

--- a/repository/kafka/operator/templates/kafka-connect-setup.yaml
+++ b/repository/kafka/operator/templates/kafka-connect-setup.yaml
@@ -39,7 +39,7 @@ spec:
               ${KAFKA_HOME}/kafka-connectors-setup register http://{{ .Name }}-connect-svc:{{ .Params.KAFKA_CONNECT_REST_PORT }} --config=/connectors-configuration/config.yaml;
             fi
             {{ else }}
-            echo "No conenctors configuration Config Map provided to KUDO Kafka. Set parameter KAFKA_CONNECT_CONNECTORS_CM to bootstrap kafka connect with providers needed."
+            echo "No connectors configuration ConfigMap provided to KUDO Kafka. Set parameter KAFKA_CONNECT_CONNECTORS_CM to bootstrap kafka connect with providers needed."
             {{ end }}
         {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
         volumeMounts:

--- a/repository/kafka/operator/templates/kafka-connect-setup.yaml
+++ b/repository/kafka/operator/templates/kafka-connect-setup.yaml
@@ -1,0 +1,58 @@
+{{ if eq .Params.KAFKA_CONNECT_ENABLED "true" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Name }}-connect-setup
+  namespace: {{ .Namespace }}
+  labels:
+    app: kafka-connect-setup
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: kafka-connect-setup
+        image: shubhanilbag/kafka:2.4.0-1.2.1
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 100m
+            memory: 30Mi
+          limits:
+            cpu: 100m
+            memory: 50Mi
+        command:
+          - bash
+          - -c
+        args:
+          - while ! nc -z {{ .Name }}-connect-svc {{ .Params.KAFKA_CONNECT_REST_PORT }} </dev/null;
+            do
+              echo "Waiting 10 secs for {{ .Name }}-connect-svc:{{ .Params.KAFKA_CONNECT_REST_PORT }} to be available";
+              sleep 10;
+            done;
+            {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
+            if [ -e "/connectors-configuration/config.json" ]; then
+              ${KAFKA_HOME}/kafka-connectors-setup register http://{{ .Name }}-connect-svc:{{ .Params.KAFKA_CONNECT_REST_PORT }} --config=/connectors-configuration/config.json;
+            elif [ -e "/connectors-configuration/config.yaml" ]; then 
+              ${KAFKA_HOME}/kafka-connectors-setup register http://{{ .Name }}-connect-svc:{{ .Params.KAFKA_CONNECT_REST_PORT }} --config=/connectors-configuration/config.yaml;
+            fi
+            {{ else }}
+            echo "No conenctors configuration Config Map provided to KUDO Kafka. Set parameter KAFKA_CONNECT_CONNECTORS_CM to bootstrap kafka connect with providers needed."
+            {{ end }}
+        {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
+        volumeMounts:
+          - name: connectors-configuration
+            mountPath: /connectors-configuration
+        {{ end }}
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+      volumes:
+        {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
+        - name: connectors-configuration
+          configMap:
+            name: {{ .Params.KAFKA_CONNECT_CONNECTORS_CM }}
+        {{ end }}
+{{ end }}

--- a/repository/kafka/operator/templates/kafka-connect.yaml
+++ b/repository/kafka/operator/templates/kafka-connect.yaml
@@ -1,4 +1,3 @@
-{{ if eq .Params.KAFKA_CONNECT_ENABLED "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,7 +17,7 @@ spec:
     spec:
       containers:
       - name: kafka-connect
-        image: shubhanilbag/kafka:2.4.0-1.3.0
+        image: mesosphere/kafka:2.4.0-1.3.0
         imagePullPolicy: Always
         resources:
           requests:
@@ -88,4 +87,3 @@ spec:
         {{ end }}
   strategy:
     type: Recreate
-{{ end }}

--- a/repository/kafka/operator/templates/kafka-connect.yaml
+++ b/repository/kafka/operator/templates/kafka-connect.yaml
@@ -39,20 +39,28 @@ spec:
             pushd /opt/kafka/connectors;
             {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
             if [ -e "/connectors-configuration/config.json" ]; then
-              ${KAFKA_HOME}/kafka-connectors-setup download --config==/connectors-configuration/config.json;
+              ${KAFKA_HOME}/kafka-connectors-setup download --config=/connectors-configuration/config.json;
             elif [ -e "/connectors-configuration/config.yaml" ]; then 
-              ${KAFKA_HOME}/kafka-connectors-setup download --config==/connectors-configuration/config.yaml;
+              ${KAFKA_HOME}/kafka-connectors-setup download --config=/connectors-configuration/config.yaml;
             fi
             {{ end }}
             popd;
-            exec ${KAFKA_HOME}/bin/connect-distributed.sh /kafka-connect-config/connect-distributed.properties
+            cp /kafka-connect-config/connect-distributed.properties ${KAFKA_HOME}/connect-distributed.properties
+            {{ if .Params.KAFKA_CONNECT_CUSTOM_CM }}
+            cat /custom-configuration/custom.properties >> ${KAFKA_HOME}/connect-distributed.properties
+            {{ end }}
+            exec ${KAFKA_HOME}/bin/connect-distributed.sh ${KAFKA_HOME}/connect-distributed.properties
         volumeMounts:
+          - name: kafka-connect-config
+            mountPath: /kafka-connect-config
+          {{ if .Params.KAFKA_CONNECT_CUSTOM_CM }}
+          - name: custom-configuration
+            mountPath: /custom-configuration
+          {{ end }}
           {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
           - name: connectors-configuration
             mountPath: /connectors-configuration
           {{ end }}
-          - name: kafka-connect-config
-            mountPath: /kafka-connect-config
         readinessProbe:
           tcpSocket:
             port: {{ .Params.KAFKA_CONNECT_REST_PORT }}
@@ -68,6 +76,11 @@ spec:
         - name: kafka-connect-config
           configMap:
             name: {{ .Name }}-kafka-connect-config
+        {{ if .Params.KAFKA_CONNECT_CUSTOM_CM }}
+        - name: custom-configuration
+          configMap:
+            name: {{ .Params.KAFKA_CONNECT_CUSTOM_CM }}
+        {{ end }}
         {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
         - name: connectors-configuration
           configMap:

--- a/repository/kafka/operator/templates/kafka-connect.yaml
+++ b/repository/kafka/operator/templates/kafka-connect.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Params.KAFKA_CONNECT_ENABLED "true" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Name }}-connect
@@ -8,9 +8,9 @@ metadata:
     app: kafka-connect
 spec:
   replicas: {{ .Params.KAFKA_CONNECT_REPLICA_COUNT }}
-  namespaceSelector:
-    matchNames:
-    - {{ .Namespace }}
+  selector:
+    matchLabels:
+      app: kafka-connect
   template:
     metadata:
       labels:
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: kafka-connect
-        image: shubhanilbag/kafka:2.4.0-1.2.1
+        image: shubhanilbag/kafka:2.4.0-1.3.0
         imagePullPolicy: Always
         resources:
           requests:
@@ -45,11 +45,11 @@ spec:
             fi
             {{ end }}
             popd;
-            cp /kafka-connect-config/connect-distributed.properties ${KAFKA_HOME}/connect-distributed.properties
+            cp /kafka-connect-config/connect-distributed.properties ${KAFKA_HOME}/connect-distributed.properties;
             {{ if .Params.KAFKA_CONNECT_CUSTOM_CM }}
-            cat /custom-configuration/custom.properties >> ${KAFKA_HOME}/connect-distributed.properties
+            cat /custom-configuration/custom.properties >> ${KAFKA_HOME}/connect-distributed.properties;
             {{ end }}
-            exec ${KAFKA_HOME}/bin/connect-distributed.sh ${KAFKA_HOME}/connect-distributed.properties
+            exec ${KAFKA_HOME}/bin/connect-distributed.sh ${KAFKA_HOME}/connect-distributed.properties;
         volumeMounts:
           - name: kafka-connect-config
             mountPath: /kafka-connect-config

--- a/repository/kafka/operator/templates/kafka-connect.yaml
+++ b/repository/kafka/operator/templates/kafka-connect.yaml
@@ -1,0 +1,78 @@
+{{ if eq .Params.KAFKA_CONNECT_ENABLED "true" }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Name }}-connect
+  namespace: {{ .Namespace }}
+  labels:
+    app: kafka-connect
+spec:
+  replicas: {{ .Params.KAFKA_CONNECT_REPLICA_COUNT }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Namespace }}
+  template:
+    metadata:
+      labels:
+        app: kafka-connect
+    spec:
+      containers:
+      - name: kafka-connect
+        image: shubhanilbag/kafka:2.4.0-1.2.1
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: {{ .Params.KAFKA_CONNECT_CPUS }}
+            memory: {{ .Params.KAFKA_CONNECT_MEM }}
+          limits:
+            cpu: {{ .Params.KAFKA_CONNECT_CPUS_LIMIT }}
+            memory: {{ .Params.KAFKA_CONNECT_MEM_LIMIT }}
+        ports:
+          - containerPort: {{ .Params.KAFKA_CONNECT_REST_PORT }}
+            name: server
+        command:
+          - bash
+          - -c
+          - -x
+        args:
+          - mkdir -p /opt/kafka/connectors;
+            pushd /opt/kafka/connectors;
+            {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
+            if [ -e "/connectors-configuration/config.json" ]; then
+              ${KAFKA_HOME}/kafka-connectors-setup download --config==/connectors-configuration/config.json;
+            elif [ -e "/connectors-configuration/config.yaml" ]; then 
+              ${KAFKA_HOME}/kafka-connectors-setup download --config==/connectors-configuration/config.yaml;
+            fi
+            {{ end }}
+            popd;
+            exec ${KAFKA_HOME}/bin/connect-distributed.sh /kafka-connect-config/connect-distributed.properties
+        volumeMounts:
+          {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
+          - name: connectors-configuration
+            mountPath: /connectors-configuration
+          {{ end }}
+          - name: kafka-connect-config
+            mountPath: /kafka-connect-config
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Params.KAFKA_CONNECT_REST_PORT }}
+          initialDelaySeconds: {{ .Params.READINESS_INITIAL_DELAY_SECONDS }}
+          periodSeconds: {{ .Params.READINESS_PERIOD_SECONDS }}
+          timeoutSeconds: {{ .Params.READINESS_TIMEOUT_SECONDS }}
+          successThreshold: {{ .Params.READINESS_SUCCESS_THRESHOLD }}
+          failureThreshold: {{ .Params.READINESS_FAILURE_THRESHOLD }}
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+      volumes:
+        - name: kafka-connect-config
+          configMap:
+            name: {{ .Name }}-kafka-connect-config
+        {{ if .Params.KAFKA_CONNECT_CONNECTORS_CM }}
+        - name: connectors-configuration
+          configMap:
+            name: {{ .Params.KAFKA_CONNECT_CONNECTORS_CM }}
+        {{ end }}
+  strategy:
+    type: Recreate
+{{ end }}

--- a/repository/kafka/operator/templates/mirror-maker.yaml
+++ b/repository/kafka/operator/templates/mirror-maker.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: kafka-mirror-maker
-        image: mesosphere/kafka:1.0.1-2.3.1
+        image: mesosphere/kafka:2.4.0-1.3.0
         imagePullPolicy: Always
         command:
           - bash

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -81,7 +81,7 @@ spec:
         {{ end }}
         - name: k8skafka
           imagePullPolicy: Always
-          image: mesosphere/kafka:1.1.0-2.4.0
+          image: mesosphere/kafka:2.4.0-1.3.0
           resources:
             requests:
               memory: {{ .Params.BROKER_MEM }}


### PR DESCRIPTION
This PR:
1. Adds Kafka Connect as a Deployment
2. Adds support to enable custom properties for Kafka Connect
3. Adds support to add bootstrap configuration for Kafka Connect

PR for `kafka-connectors-setup` utility https://github.com/mesosphere/kudo-kafka-operator/pull/39