### PR TITLE
add toggle features for Kafka and minor fixes around operator plan

### DIFF
--- a/repository/kafka/README.md
+++ b/repository/kafka/README.md
@@ -24,7 +24,7 @@ The latest stable version of Kafka operator is `1.2.1`
 For more details, please see the [v1.1 docs](./docs/v1.2) folder.
 
 
-## Version Chart
+## Releases
 
 | KUDO Kafka | Apache Kafka | Minimum KUDO Version |
 | ---------- | ------------ | -------------------- |
@@ -32,7 +32,11 @@ For more details, please see the [v1.1 docs](./docs/v1.2) folder.
 | 1.0.1      | 2.3.1        | 0.8.0                |
 | 1.0.2      | 2.3.1        | 0.8.0                |
 | 1.1.0      | 2.4.0        | 0.9.0                |
-| 1.2.0      | 2.4.0        | 0.10.0               |
-| **1.2.1**  | **2.4.0**    | **0.10.0**           |
-| latest     | 2.4.0        | 0.10.0               |
+| **1.2.0**  | **2.4.0**    | **0.10.0**           |
 
+## Upcoming releases
+
+| KUDO Kafka | Apache Kafka | Minimum KUDO Version |
+| ---------- | ------------ | -------------------- |
+| 1.2.1      | 2.4.1        | 0.11.0               |
+| 1.3.0      | 2.5.0        | 0.11.0               |

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -80,7 +80,7 @@ tasks:
   - name: not-allowed
     kind: Dummy
     spec:
-      resources:
+      done: true
 plans:
   deploy:
     strategy: serial

--- a/repository/kafka/operator/operator.yaml
+++ b/repository/kafka/operator/operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: kudo.dev/v1beta1
 name: "kafka"
 operatorVersion: "1.2.1"
-kudoVersion: 0.10.0
+kudoVersion: 0.11.0
 kubernetesVersion: 1.14.8
 appVersion: 2.4.0
 maintainers:
@@ -11,18 +11,32 @@ maintainers:
     email: sbag.c@d2iq.com
 url: https://kafka.apache.org/
 tasks:
-  - name: deploy
+  # configuration and application tasks
+  - name: sts
     kind: Apply
     spec:
       resources:
         - pdb.yaml
         - statefulset.yaml
-  - name: mirrormaker
+  - name: configuration
     kind: Apply
     spec:
       resources:
-        - mirror-maker-config.yaml
-        - mirror-maker.yaml
+        - serviceaccount.yaml
+        - rolebinding.yaml
+        - role.yaml
+        - jaas-config.yaml
+        - krb5-config.yaml
+        - server.properties.yaml
+        - bootstrap.yaml
+        - metrics-config.yaml
+        - health-check.yaml
+        - enable-tls.yaml
+  - name: service
+    kind: Apply
+    spec:
+      resources:
+        - service.yaml
   - name: generate-tls-certificates
     kind: Pipe
     spec:
@@ -34,38 +48,35 @@ tasks:
         - file: /tmp/tls.crt
           kind: Secret
           key: certificate
-  - name: user-workload
-    kind: Apply
+  # feature tasks
+  - name: service-monitor
+    kind: Toggle
     spec:
+      parameter: ADD_SERVICE_MONITOR
       resources:
-      - user-workload.yaml
-  - name: service
-    kind: Apply
-    spec:
-      resources:
-      - service.yaml
-      - service-monitor.yaml
+        - service-monitor.yaml
   - name: external-access
-    kind: Apply
+    kind: Toggle
     spec:
+      parameter: EXTERNAL_ADVERTISED_LISTENER
       resources:
-      - clusterrole.yaml
-      - clusterrolebinding.yaml
-      - external-service.yaml
-  - name: configuration
-    kind: Apply
+        - clusterrole.yaml
+        - clusterrolebinding.yaml
+        - external-service.yaml
+  - name: mirrormaker
+    kind: Toggle
     spec:
+      parameter: MIRROR_MAKER_ENABLED
       resources:
-      - serviceaccount.yaml
-      - rolebinding.yaml
-      - role.yaml
-      - jaas-config.yaml
-      - krb5-config.yaml
-      - server.properties.yaml
-      - bootstrap.yaml
-      - metrics-config.yaml
-      - health-check.yaml
-      - enable-tls.yaml
+        - mirror-maker-config.yaml
+        - mirror-maker.yaml
+  - name: user-workload
+    kind: Toggle
+    spec:
+      parameter: RUN_USER_WORKLOAD
+      resources:
+        - user-workload.yaml
+  # task used to restrict patching sts where it is not allowed
   - name: not-allowed
     kind: Dummy
     spec:
@@ -79,7 +90,7 @@ plans:
         steps:
           - name: generate-tls-certificates
             tasks:
-              - generate-tls-certificates 
+              - generate-tls-certificates
           - name: configuration
             tasks:
               - configuration
@@ -88,16 +99,43 @@ plans:
               - service
           - name: app
             tasks:
-              - deploy
-          - name: addons
+              - sts
+      - name: addons
+        strategy: parallel
+        steps:
+          - name: monitoring
+            tasks:
+              - service-monitor
+          - name: access
             tasks:
               - external-access
+          - name: mirror
+            tasks:
               - mirrormaker
+          - name: load
+            tasks:
               - user-workload
+  # update-configuration and roll out sts
+  update:
+    strategy: serial
+    phases:
+      - name: app
+        strategy: serial
+        steps:
+          - name: conf
+            tasks:
+              - configuration
+          - name: svc
+            tasks:
+              - service
+          - name: sts
+            tasks:
+              - sts
+  # features plans
   mirrormaker:
     strategy: serial
     phases:
-      - name: deploy-mirror-maker
+      - name: app
         strategy: serial
         steps:
           - name: deploy
@@ -106,30 +144,41 @@ plans:
   external-access:
     strategy: serial
     phases:
-      - name: external-access-resources
+      - name: resources
         strategy: serial
         steps:
-          - name: external
+          - name: deploy
             tasks:
               - external-access
-              - deploy
+              - configuration
+              - service
+              - sts
   service-monitor:
     strategy: serial
     phases:
       - name: enable-service-monitor
         strategy: serial
         steps:
-        - name: add-service-monitor
-          tasks:
-            - service
+          - name: deploy
+            tasks:
+              - service-monitor
+  user-workload:
+    strategy: serial
+    phases:
+      - name: workload
+        strategy: serial
+        steps:
+          - name: toggle-workload
+            tasks:
+              - user-workload
   # this plan is triggered when some parameter present in limitations is updated
   # https://github.com/kudobuilder/operators/blob/master/repository/kafka/docs/latest/limitations.md
   not-allowed:
     strategy: serial
     phases:
-    - name: not-allowed
-      strategy: serial
-      steps:
-        - name: not-allowed
-          tasks:
-          - not-allowed
+      - name: not-allowed
+        strategy: serial
+        steps:
+          - name: not-allowed
+            tasks:
+              - not-allowed

--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -3,49 +3,63 @@ parameters:
   - name: AUTHORIZATION_ENABLED
     description: "Enable authorization."
     default: "false"
+    trigger: "update"
     displayName: "Authorization Enabled"
   - name: AUTHORIZATION_SUPER_USERS
     description: "Semi-colon delimited list of principals. For Kerberos principals, these will be of the form User:<Kerberos-Primary>. For TLS, they will be of the form User:<CN of TLS cert> (for the TLS cert CN=test-user,OU=,O=Confluent,L=London,ST=London,C=GB, the user would be test-user)"
     default: ""
+    trigger: "update"
     displayName: "Super Users"
   - name: AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND
     description: "Allow any user to perform an action if no ACL is found for the resource."
     default: "false"
+    trigger: "update"
     displayName: "Allow everyone if no acl found"
   - name: BROKER_COUNT
     description: "Number of brokers spun up for Kafka"
     default: "3"
+    trigger: "update"
     displayName: "Broker Count"
   - name: BROKER_CPUS
     description: "CPUs (request) for the Kafka Broker container"
     default: "500m"
+    trigger: "update"
   - name: BROKER_CPUS_LIMIT
     description: "CPUs (limit) for the Kafka Broker container"
     default: "2000m"
+    trigger: "update"
   - name: BROKER_MEM
     description: "Memory (request) for the Kafka Broker container"
     default: "2048Mi"
+    trigger: "update"
   - name: BROKER_MEM_LIMIT
     description: "Memory (limit) for the Kafka Broker container"
     default: "4096Mi"
+    trigger: "update"
   - name: NE_MEM
     default: "20Mi"
+    trigger: "update"
     description: "Memory (request) for the Kafka node exporter sidecar"
   - name: NE_CPUS
     default: "100m"
+    trigger: "update"
     description: "CPUs (request) for the Kafka node exporter sidecar"
   - name: NE_MEM_LIMIT
     default: "512Mi"
+    trigger: "update"
     description: "Memory (limit) for the Kafka node exporter sidecar"
   - name: NE_CPUS_LIMIT
     default: "1500m"
+    trigger: "update"
     description: "CPUs (limit) for the Kafka node exporter sidecar"
   - name: BROKER_PORT
     description: "Port brokers run on"
     default: "9093"
+    trigger: "update"
   - name: BROKER_PORT_TLS
     description: "Port TLS-enabled brokers run on"
     default: "9095"
+    trigger: "update"
   - name: DISK_SIZE
     description: "Disk size for the brokers"
     default: "5Gi"
@@ -61,16 +75,21 @@ parameters:
   - name: CLIENT_PORT
     description: "Broker client port"
     default: "9092"
+    trigger: "update"
   - name: CLIENT_PORT_ENABLED
     default: "true"
+    trigger: "update"
   - name: METRICS_PORT
     description: "Port JMX_EXPORTER binds"
     default: "9094"
+    trigger: "update"
   - name: KAFKA_NODE_EXPORTER_PORT
     description: "Port NODE_EXPORTER binds"
     default: "9096"
+    trigger: "update"
   - name: METRICS_ENABLED
     default: "true"
+    trigger: "update"
   - name: ADD_SERVICE_MONITOR
     description: "Create a service monitor for the kafka service"
     default: "false"
@@ -78,9 +97,11 @@ parameters:
   - name: RUN_USER_WORKLOAD
     description: "Run dummy user workload on the kafka service"
     default: "false"
+    trigger: "user-workload"
   - name: NUM_PARTITIONS
     description: "Number of partitions for Kafka topics"
     default: "3"
+    trigger: "update"
   - name: ZOOKEEPER_URI
     displayName: "zookeeper cluster URI"
     description: |
@@ -92,13 +113,17 @@ parameters:
     displayName: "zookeeper node path"
     description: "Zookeeper node path. Defaults to Kafka instance name."
     required: false
+    trigger: "update"
   - name: AUTO_CREATE_TOPICS_ENABLE
     default: "true"
+    trigger: "update"
   - name: AUTO_LEADER_REBALANCE_ENABLE
     default: "true"
+    trigger: "update"
   - name: BACKGROUND_THREADS
     description: "The number of threads to use for various background processing tasks"
     default: "10"
+    trigger: "update"
   - name: COMPRESSION_TYPE
     default: "producer"
     description: |
@@ -108,141 +133,177 @@ parameters:
     displayName: "delete.topic.enable"
     default: "false"
     description: "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off"
+    trigger: "update"
   - name: DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS
     default: "1"
     description: "The purge interval (in number of requests) of the delete records request purgatory"
+    trigger: "update"
   - name: KERBEROS_ENABLED
     description: "Enable kerberos authentication."
     default: "false"
     displayName: "Kerberos Enabled"
+    trigger: "update"
   - name: KERBEROS_ENABLED_FOR_ZOOKEEPER
     description: "Enable Kerberos authentication for communication with Apache Zookeeper."
     default: "false"
     displayName: "Zookeeper Kerberos Enabled"
+    trigger: "update"
   - name: KERBEROS_PRIMARY
     description: "The Kerberos primary used by Kafka tasks."
     default: "kafka"
     displayName: "Kerberos Primary"
+    trigger: "update"
   - name: KERBEROS_KEYTAB_SECRET
     description: "The name of the Kubernetes secret storing the keytab."
     default: "base64-kafka-keytab-secret"
     displayName: "Kerberos Keytab Secret"
+    trigger: "update"
   - name: KERBEROS_REALM
     description: "The Kerberos realm used to render the principal of Kafka broker pods."
     default: "LOCAL"
     displayName: "Kerberos Realm"
+    trigger: "update"
   - name: KERBEROS_KDC_HOSTNAME
     description: "The name or address of a host running a KDC for the realm."
     default: "kdc-service"
     displayName: "Kerberos Hostname"
+    trigger: "update"
   - name: KERBEROS_KDC_PORT
     description: "The port of the host running a KDC for that realm."
     default: "2500"
     displayName: "Kerberos Port"
+    trigger: "update"
   - name: KERBEROS_USE_TCP
     description: "Use TCP for KDC connection, by default it uses UDP protocol"
     default: "false"
     displayName: "Use TCP for Kerberos"
+    trigger: "update"
   - name: KERBEROS_DEBUG
     description: "Turn debug Kerberos logging on or off to assist in diagnosing issues with Kerberos authentication."
     default: "false"
     displayName: "Kerberos Debug"
+    trigger: "update"
   - name: LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS
     default: "300"
     description: "The frequency with which the partition rebalance check is triggered by the controller"
+    trigger: "update"
   - name: LEADER_IMBALANCE_PER_BROKER_PERCENTAGE
     default: "10"
     description: "The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage."
+    trigger: "update"
   - name: LIVENESS_INITIAL_DELAY_SECONDS
     displayName: "livenessProbe initial delay timeout seconds"
     description: "Number of seconds after the container has started before liveness probes is initiated."
     default: "30"
+    trigger: "update"
   - name: LIVENESS_PERIOD_SECONDS
     displayName: "livenessProbe period seconds"
     description: "How often (in seconds) to perform the probe. Default to 30 seconds. Minimum value is 1."
     default: "30"
+    trigger: "update"
   - name: LIVENESS_TIMEOUT_SECONDS
     displayName: "livenessProbe timeout seconds"
     description: "Number of seconds after which the probe times out. Defaults to 30 seconds. Minimum value is 1."
     default: "30"
+    trigger: "update"
   - name: LIVENESS_FAILURE_THRESHOLD
     displayName: "livenessProbe timeout seconds"
     description: "When the Pod starts and the probe fails, Kubernetes will try failureThreshold times before restarting the Pod. Defaults to 3. Minimum value is 1."
     default: "3"
+    trigger: "update"
   - name: LIVENESS_METHOD
     displayName: "livenessProbe method"
     description: "livenessProbe method values 'PORT' or 'FUNCTIONAL'"
     default: "PORT"
+    trigger: "update"
   - name: LIVENESS_TOPIC_PREFIX
     displayName: "livenessProbe topic prefix"
     description: "This topic is used by livenessProbe when 'FUNCTIONAL' method is selected."
     default: "KafkaLivenessTopic"
+    trigger: "update"
   - name: LIVENESS_KERBEROS_PRIMARY
     default: "livenessProbe"
+    trigger: "update"
     description: "The Kerberos primary used by the liveness probe when using FUNCTIONAL livenessProbe method."
     displayName: "Liveness Probe Kerberos Primary"
   - name: LOG_FLUSH_INTERVAL_MESSAGES
     default: "9223372036854775807"
+    trigger: "update"
     description: "The number of messages accumulated on a log partition before messages are flushed to disk"
   - name: LOG_FLUSH_INTERVAL_MS
     default: "9223372036854775807"
+    trigger: "update"
     description: "The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used"
   - name: LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS
     default: "60000"
+    trigger: "update"
     description: "The frequency with which we update the persistent record of the last flush which acts as the log recovery point"
   - name: LOG_FLUSH_SCHEDULER_INTERVAL_MS
     default: "9223372036854775807"
+    trigger: "update"
     description: "The frequency in ms that the log flusher checks whether any log needs to be flushed to disk"
   - name: LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS
     default: "60000"
+    trigger: "update"
     description: "The frequency with which we update the persistent record of log start offset"
   - name: LOG_RETENTION_BYTES
     displayName: "log.retention.bytes"
     description: "The maximum size of the log before deleting it"
     default: "-1"
+    trigger: "update"
   - name: LOG_RETENTION_MS
     displayName: "log.retention.ms"
     description: "The number of milliseconds to keep a log file before deleting it (in milliseconds) If not set, the value in log.retention.minutes is used"
     required: false
+    trigger: "update"
   - name: LOG_RETENTION_MINUTES
     displayName: "log.retention.minutes"
     description: "The number of minutes to keep a log file before deleting it (in minutes), secondary to log.retention.ms property. If not set, the value in log.retention.hours is used"
     required: false
+    trigger: "update"
   - name: LOG_RETENTION_HOURS
     displayName: "log.retention.hours"
     description: "The number of hours to keep a log file before deleting it (in hours), tertiary to log.retention.ms property"
     default: "168"
     required: false
+    trigger: "update"
   - name: LOG_ROLL_MS
     displayName: "log.roll.ms"
     description: "The maximum time before a new log segment is rolled out (in milliseconds). If not set, the value in log.roll.hours is used"
     required: false
+    trigger: "update"
   - name: LOG_ROLL_JITTER_MS
     displayName: "log.roll.jitter.ms"
     description: "The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used"
     required: false
+    trigger: "update"
   - name: LOG_ROLL_HOURS
     displayName: "log.roll.hours"
     description: "The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property"
     default: "168"
     required: false
+    trigger: "update"
   - name: LOG_ROLL_JITTER_HOURS
     displayName: "log.roll.jitter.hours"
     description: "The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property"
     default: "0"
     required: false
+    trigger: "update"
   - name: LOG_SEGMENT_BYTES
     displayName: "log.segment.bytes"
     description: "The maximum size of a single log file"
     default: "1073741824"
+    trigger: "update"
   - name: LOG_SEGMENT_DELETE_DELAY_MS
     displayName: "log.segment.delete.delay.ms"
     description: "The amount of time to wait before deleting a file from the filesystem"
     default: "60000"
+    trigger: "update"
   - name: MESSAGE_MAX_BYTES
     displayName: "message.max.bytes"
     description: "The largest record batch size allowed by Kafka. If this is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that the they can fetch record batches this large.\nIn the latest message format version, records are always grouped into batches for efficiency. In previous message format versions, uncompressed records are not grouped into batches and this limit only applies to a single record in that case.\nThis can be set per  topic with the topic level max.message.bytes config."
     default: "1000012"
+    trigger: "update"
   - name: MIN_INSYNC_REPLICAS
     displayName: "min.insync.replicas"
     description: |
@@ -250,186 +311,232 @@ parameters:
       When used together, min.insync.replicas and acks allow you to enforce greater durability guarantees.
       A typical scenario would be to create a topic with a replication factor of 3, set min.insync.replicas to 2, and produce with acks of "all".
     default: "1"
+    trigger: "update"
   - name: NUM_IO_THREADS
     displayName: "num.io.threads"
     description: "The number of threads that the server uses for processing requests, which may include disk I/O"
     default: "8"
+    trigger: "update"
   - name: NUM_NETWORK_THREADS
     displayName: "num.network.threads"
     description: "The number of threads that the server uses for receiving requests from the network and sending responses to the network"
     default: "3"
+    trigger: "update"
   - name: NUM_RECOVERY_THREADS_PER_DATA_DIR
     displayName: "num.recovery.threads.per.data.dir"
     description: "The number of threads per data directory to be used for log recovery at startup and flushing at shutdown"
     default: "1"
+    trigger: "update"
   - name: NUM_REPLICA_FETCHERS
     displayName: "num.replica.fetchers"
     description: "Number of fetcher threads used to replicate messages from a source broker. Increasing this value can increase the degree of I/O parallelism in the follower broker."
     default: "1"
+    trigger: "update"
   - name: OFFSET_METADATA_MAX_BYTES
     displayName: "offset.metadata.max.bytes"
     description: "The maximum size for a metadata entry associated with an offset commit"
     default: "4096"
+    trigger: "update"
   - name: OFFSETS_COMMIT_REQUIRED_ACKS
     displayName: "offsets.commit.required.acks"
     description: "The required acks before the commit can be accepted. In general the default (-1) should not be overridden"
     default: -1
+    trigger: "update"
   - name: OFFSETS_COMMIT_TIMEOUT_MS
     displayName: "offsets.commit.timeout.ms"
     description: "Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout."
     default: "5000"
+    trigger: "update"
   - name: OFFSETS_LOAD_BUFFER_SIZE
     displayName: "offsets.load.buffer.size"
     description: "Batch size for reading from the offsets segments when loading offsets into the cache."
     default: "5242880"
+    trigger: "update"
   - name: OFFSETS_RETENTION_CHECK_INTERVAL_MS
     displayName: "offsets.retention.check.interval.ms"
     description: "Frequency at which to check for stale offsets"
     default: "600000"
+    trigger: "update"
   - name: OFFSETS_RETENTION_MINUTES
     displayName: "offsets.retention.minutes"
     description: "Offsets older than this retention period will be discarded"
     default: "1440"
+    trigger: "update"
   - name: OFFSETS_TOPIC_COMPRESSION_CODEC
     displayName: "offsets.topic.compression.codec"
     description: "Compression codec for the offsets topic - compression may be used to achieve \"atomic\" commits"
     default: "0"
+    trigger: "update"
   - name: OFFSETS_TOPIC_NUM_PARTITIONS
     displayName: "offsets.topic.num.partitions"
     description: "The number of partitions for the offset commit topic (should not change after deployment)"
     default: "50"
+    trigger: "update"
   - name: OFFSETS_TOPIC_REPLICATION_FACTOR
     displayName: "offsets.topic.replication.factor"
     description: "The replication factor for the offsets topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement."
     default: "3"
+    trigger: "update"
   - name: OFFSETS_TOPIC_SEGMENT_BYTES
     displayName: "offsets.topic.segment.bytes"
     description: "The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads"
     default: "104857600"
+    trigger: "update"
   - name: QUEUED_MAX_REQUESTS
     displayName: "queued.max.requests"
     description: "The number of queued requests allowed before blocking the network threads"
     default: "500"
+    trigger: "update"
   - name: QUEUED_MAX_REQUEST_BYTES
     displayName: "queued.max.request.bytes"
     description: "The number of queued bytes allowed before no more requests are read"
     default: -1
+    trigger: "update"
   - name: QUOTA_CONSUMER_DEFAULT
     displayName: "quota.consumer.default"
     description: "Used only when dynamic default quotas are not configured for or in Zookeeper. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second"
     default: "9223372036854775807"
+    trigger: "update"
   - name: QUOTA_PRODUCER_DEFAULT
     displayName: "quota.producer.default"
     description: "Used only when dynamic default quotas are not configured for , or in Zookeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second"
     default: "9223372036854775807"
+    trigger: "update"
   - name: READINESS_INITIAL_DELAY_SECONDS
     displayName: "livenessProbe initial delay timeout seconds"
     description: "Number of seconds after the container has started before liveness probes is initiated. Defaults to 10."
     default: "10"
+    trigger: "update"
   - name: READINESS_PERIOD_SECONDS
     displayName: "livenessProbe period seconds"
     description: "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1."
     default: "10"
+    trigger: "update"
   - name: READINESS_TIMEOUT_SECONDS
     displayName: "readinessProbe timeout seconds"
     description: "Number of seconds after which the probe times out. Defaults to 30 seconds. Minimum value is 1."
     default: "30"
+    trigger: "update"
   - name: READINESS_SUCCESS_THRESHOLD
     displayName: "livenessProbe timeout seconds"
     description: "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Minimum value is 1."
     default: "1"
+    trigger: "update"
   - name: READINESS_FAILURE_THRESHOLD
     displayName: "livenessProbe timeout seconds"
     description: "When a Pod starts and the probe fails, Kubernetes will try failureThreshold times before the Pod will be marked Unready. Defaults to 3. Minimum value is 1."
     default: "3"
+    trigger: "update"
   - name: REPLICA_FETCH_MAX_BYTES
     displayName: "replica.fetch.max.bytes"
     description: "The number of bytes of messages to attempt to fetch for each partition. This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value the record batch will still be returned to ensure that progress can be made. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config)."
     default: "1048576"
+    trigger: "update"
   - name: REPLICA_FETCH_MIN_BYTES
     displayName: "replica.fetch.min.bytes"
     description: "Minimum bytes expected for each fetch response. If not enough bytes, wait up to replicaMaxWaitTimeMs"
     default: "1"
+    trigger: "update"
   - name: REPLICA_FETCH_WAIT_MAX_MS
     displayName: "replica.fetch.wait.max.ms"
     description: "Max wait time for each fetcher request issued by follower replicas. This value should always be less than the replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics"
     default: "500"
+    trigger: "update"
   - name: REPLICA_FETCH_RESPONSE_MAX_BYTES
     displayName: "replica.fetch.response.max.bytes"
     description: "Maximum bytes expected for the entire fetch response. Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value the record batch will still be returned to ensure that progress can be made. As such this is not an absolute maximum. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config)."
     default: "10485760"
+    trigger: "update"
   - name: REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS
     displayName: "replica.high.watermark.checkpoint.interval.ms"
     description: "The frequency with which the high watermark is saved out to disk"
     default: "5000"
+    trigger: "update"
   - name: REPLICA_LAG_TIME_MAX_MS
     displayName: "replica.lag.time.max.ms"
     description: "If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time, the leader will remove the follower from isr"
     default: "10000"
+    trigger: "update"
   - name: REPLICA_SOCKET_RECEIVE_BUFFER_BYTES
     displayName: "replica.socket.receive.buffer.bytes"
     description: "The socket receive buffer for network requests"
     default: "65536"
+    trigger: "update"
   - name: REPLICA_SOCKET_TIMEOUT_MS
     displayName: "replica.socket.timeout.ms"
     description: "The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms"
     default: "30000"
+    trigger: "update"
   - name: REPLICATION_QUOTA_WINDOW_NUM
     displayName: "replication.quota.window.num"
     description: "The number of samples to retain in memory for replication quotas"
     default: "11"
+    trigger: "update"
   - name: REPLICATION_QUOTA_WINDOW_SIZE_SECONDS
     displayName: "replication.quota.window.size.seconds"
     description: "The time span of each sample for replication quotas"
     default: "1"
+    trigger: "update"
   - name: REQUEST_TIMEOUT_MS
     displayName: "request.timeout.ms"
     description: "The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted."
     default: "30000"
+    trigger: "update"
   - name: SOCKET_RECEIVE_BUFFER_BYTES
     displayName: "socket.receive.buffer.bytes"
     description: "The SO_RCVBUF buffer of the socket sever sockets. If the value is -1 the OS default will be used."
     default: "102400"
+    trigger: "update"
   - name: SOCKET_REQUEST_MAX_BYTES
     displayName: "socket.request.max.bytes"
     description: "The maximum number of bytes in a socket request"
     default: "104857600"
+    trigger: "update"
   - name: SOCKET_SEND_BUFFER_BYTES
     displayName: "socket.send.buffer.bytes"
     description: "The SO_SNDBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used."
     default: "102400"
+    trigger: "update"
   - name: UNCLEAN_LEADER_ELECTION_ENABLE
     displayName: "unclean.leader.election.enable"
     description: "Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss"
     default: "false"
+    trigger: "update"
   - name: ZOOKEEPER_SESSION_TIMEOUT_MS
     displayName: "zookeeper.session.timeout.ms"
     description: "Zookeeper session timeout"
     default: "6000"
+    trigger: "update"
   - name: CONNECTIONS_MAX_IDLE_MS
     displayName: "connections.max.idle.ms"
     description: "Idle connections timeout: the server socket processor threads close the connections that idle more than this"
     default: "600000"
+    trigger: "update"
   - name: CONTROLLED_SHUTDOWN_ENABLE
     displayName: "controlled.shutdown.enable"
     description: "Enable controlled shutdown of the server"
     default: "true"
+    trigger: "update"
   - name: CONTROLLED_SHUTDOWN_MAX_RETRIES
     displayName: "controlled.shutdown.max.retries"
     description: "Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens"
     default: "3"
+    trigger: "update"
   - name: CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS
     displayName: "controlled.shutdown.retry.backoff.ms"
     description: "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying."
     default: "5000"
+    trigger: "update"
   - name: CONTROLLER_SOCKET_TIMEOUT_MS
     displayName: "controller.socket.timeout.ms"
     description: "The socket timeout for controller-to-broker channels"
     default: "30000"
+    trigger: "update"
   - name: DEFAULT_REPLICATION_FACTOR
     displayName: "default.replication.factor"
     description: "Default replication factors for automatically created topics"
     default: "1"
+    trigger: "update"
   - name: EXTERNAL_ADVERTISED_LISTENER
     displayName: "Enable external advertised listeners"
     description: "Enable external advertised listeners"
@@ -455,126 +562,157 @@ parameters:
     displayName: "fetch.purgatory.purge.interval.requests"
     description: "The purge interval (in number of requests) of the fetch request purgatory"
     default: "1000"
+    trigger: "update"
   - name: GROUP_MAX_SESSION_TIMEOUT_MS
     displayName: "group.max.session.timeout.ms"
     description: "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures."
     default: "300000"
+    trigger: "update"
   - name: GROUP_MIN_SESSION_TIMEOUT_MS
     displayName: "group.min.session.timeout.ms"
     description: "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating which can overwhelm broker resources."
     default: "6000"
+    trigger: "update"
   - name: GROUP_INITIAL_REBALANCE_DELAY_MS
     displayName: "group.initial.rebalance.delay.ms"
     description: "The amount of time the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins."
     default: "3000"
+    trigger: "update"
   - name: INTER_BROKER_PROTOCOL_VERSION
     displayName: "inter.broker.protocol.version"
     description: "Specify which version of the inter-broker protocol will be used, which must align with log.message.format.version. This is typically bumped *serially* one broker at a time, *after* all brokers were upgraded to a new version. Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1, 0.10.0.0, 0.10.1.x, 0.10.2.x, 0.11.0.0, 1.0, 1.1. Check ApiVersion for the full list."
     default: "2.1"
+    trigger: "update"
   - name: LOG_MESSAGE_FORMAT_VERSION
     displayName: "log.message.format.version"
     description: "Specify which version of the log message format will be used, which must align with inter.broker.protocol.version. This is a new setting as of 0.10.0.0, and should be left at 0.9.0 until clients are updated to 0.10.0.x. Similarly it should be left at 0.10.0 until all clients are updated to 0.11.0. This is typically bumped *serially* one broker at a time, *after* all inter-protocol versions are updated. Clients on earlier versions may see a performance penalty if this is increased before they've upgraded. See the latest Kafka documentation for details."
     default: "2.1"
+    trigger: "update"
   - name: LOG_CLEANER_BACKOFF_MS
     displayName: "log.cleaner.backoff.ms"
     description: "The amount of time to sleep when there are no logs to clean"
     default: "15000"
+    trigger: "update"
   - name: LOG_CLEANER_DEDUPE_BUFFER_SIZE
     displayName: "log.cleaner.dedupe.buffer.size"
     description: "The total memory used for log deduplication across all cleaner threads"
     default: "134217728"
+    trigger: "update"
   - name: LOG_CLEANER_DELETE_RETENTION_MS
     displayName: "log.cleaner.delete.retention.ms"
     description: "How long are delete records retained?"
     default: "86400000"
+    trigger: "update"
   - name: LOG_CLEANER_ENABLE
     displayName: "log.cleaner.enable"
     description: "Enable the log cleaner process to run on the server. Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size."
     default: "true"
+    trigger: "update"
   - name: LOG_CLEANER_IO_BUFFER_LOAD_FACTOR
     displayName: "log.cleaner.io.buffer.load.factor"
     description: "Log cleaner dedupe buffer load factor. The percentage full the dedupe buffer can become. A higher value will allow more log to be cleaned at once but will lead to more hash collisions"
     default: "0.9"
+    trigger: "update"
   - name: LOG_CLEANER_IO_BUFFER_SIZE
     displayName: "log.cleaner.io.buffer.size"
     description: "The total memory used for log cleaner I/O buffers across all cleaner threads"
     default: "524288"
+    trigger: "update"
   - name: LOG_CLEANER_IO_MAX_BYTES_PER_SECOND
     displayName: "log.cleaner.io.max.bytes.per.second"
     description: "The log cleaner will be throttled so that the sum of its read and write i/o will be less than this value on average"
     default: "1.7976931348623157e+308"
+    trigger: "update"
   - name: LOG_CLEANER_MIN_CLEANABLE_RATIO
     displayName: "log.cleaner.min.cleanable.ratio"
     description: "The minimum ratio of dirty log to total log for a log to eligible for cleaning"
     default: "0.5"
+    trigger: "update"
   - name: LOG_CLEANER_MIN_COMPACTION_LAG_MS
     displayName: "log.cleaner.min.compaction.lag.ms"
     description: "The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted."
     default: "0"
+    trigger: "update"
   - name: LOG_CLEANER_THREADS
     displayName: "log.cleaner.threads"
     description: "The number of background threads to use for log cleaning"
     default: "1"
+    trigger: "update"
   - name: LOG_CLEANUP_POLICY
     displayName: "log.cleanup.policy"
     description: "The default cleanup policy for segments beyond the retention window. A comma separated list of valid policies. Valid policies are: \"delete\" and \"compact\""
     default: "delete"
+    trigger: "update"
   - name: LOG_INDEX_INTERVAL_BYTES
     displayName: "log.index.interval.bytes"
     description: "The interval with which we add an entry to the offset index"
     default: "4096"
+    trigger: "update"
   - name: LOG_INDEX_SIZE_MAX_BYTES
     displayName: "log.index.size.max.bytes"
     description: "The maximum size in bytes of the offset index"
     default: "10485760"
+    trigger: "update"
   - name: LOG_PREALLOCATE
     displayName: "log.preallocate"
     description: "Should pre allocate file when create new segment? If you are using Kafka on Windows you probably need to set it to true."
     default: "false"
+    trigger: "update"
   - name: LOG_RETENTION_CHECK_INTERVAL_MS
     displayName: "log.retention.check.interval.ms"
     description: "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion"
     default: "300000"
+    trigger: "update"
   - name: MAX_CONNECTIONS_PER_IP
     displayName: "max.connections.per.ip"
     description: "The maximum number of connections we allow from each ip address"
     default: "2147483647"
+    trigger: "update"
   - name: MAX_CONNECTIONS_PER_IP_OVERRIDES
     displayName: "max.connections.per.ip.overrides"
     description: "Per-ip or hostname overrides to the default maximum number of connections"
     default: ""
+    trigger: "update"
   - name: PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS
     displayName: "producer.purgatory.purge.interval.requests"
     description: "The purge interval (in number of requests) of the producer request purgatory"
     default: "1000"
+    trigger: "update"
   - name: REPLICA_FETCH_BACKOFF_MS
     displayName: "replica.fetch.backoff.ms"
     description: "The amount of time to sleep when fetch partition error occurs."
     default: "1000"
+    trigger: "update"
   - name: RESERVED_BROKER_MAX_ID
     displayName: "reserved.broker.max.id"
     description: "Max number that can be used for a broker.id"
     default: "1000"
+    trigger: "update"
   - name: METRIC_REPORTERS
     displayName: "metric.reporters"
     description: "Java class to collect/report broker metrics"
     default: ""
+    trigger: "update"
   - name: METRICS_NUM_SAMPLES
     displayName: "metrics.num.samples"
     description: "The number of samples maintained to compute metrics."
     default: "2"
+    trigger: "update"
   - name: METRICS_SAMPLE_WINDOW_MS
     displayName: "metrics.sample.window.ms"
     description: "The window of time a metrics sample is computed over."
     default: "30000"
+    trigger: "update"
   - name: QUOTA_WINDOW_NUM
     displayName: "quota.window.num"
     description: "The number of samples to retain in memory for client quotas"
     default: "11"
+    trigger: "update"
   - name: QUOTA_WINDOW_SIZE_SECONDS
     displayName: "quota.window.size.seconds"
     description: "The time span of each sample for client quotas"
     default: "1"
+    trigger: "update"
   - name: SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
     displayName: "ssl.endpoint.identification.algorithm"
     description: |
@@ -582,65 +720,81 @@ parameters:
       Clients including client connections created by the broker for inter-broker communication verify that the broker host name matches the host name in the broker’s certificate.
       Server host name verification may be disabled by setting ssl.endpoint.identification.algorithm to an empty string.
     default: "HTTPS"
+    trigger: "update"
   - name: TRANSACTION_STATE_LOG_SEGMENT_BYTES
     displayName: "transaction.state.log.segment.bytes"
     description: "The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads"
     default: "104857600"
+    trigger: "update"
   - name: TRANSACTION_REMOVE_EXPIRED_TRANSACTION_CLEANUP_INTERVAL_MS
     displayName: "transaction.remove.expired.transaction.cleanup.interval.ms"
     description: "The interval at which to remove transactions that have expired due to transactional.id.expiration.ms passing"
     default: "3600000"
+    trigger: "update"
   - name: TRANSACTION_MAX_TIMEOUT_MS
     displayName: "transaction.max.timeout.ms"
     description: "The maximum allowed timeout for transactions. If a client's requested transaction time exceeds this then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout which can stall consumers reading from topics included in the transaction."
     default: "900000"
+    trigger: "update"
   - name: TRANSACTION_STATE_LOG_NUM_PARTITIONS
     displayName: "transaction.state.log.num.partitions"
     description: "The number of partitions for the transaction topic (should not change after deployment)."
     default: "50"
+    trigger: "update"
   - name: TRANSACTION_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS
     displayName: "transaction.abort.timed.out.transaction.cleanup.interval.ms"
     description: "The interval at which to rollback transactions that have timed out"
     default: "60000"
+    trigger: "update"
   - name: TRANSACTION_STATE_LOG_LOAD_BUFFER_SIZE
     displayName: "transaction.state.log.load.buffer.size"
     description: "Batch size for reading from the transaction log segments when loading producer ids and transactions into the cache."
     default: "5242880"
+    trigger: "update"
   - name: TRANSACTION_STATE_LOG_REPLICATION_FACTOR
     displayName: "transaction.state.log.replication.factor"
     description: "The replication factor for the transaction topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement."
     default: "3"
+    trigger: "update"
   - name: TRANSACTION_STATE_LOG_MIN_ISR
     displayName: "transaction.state.log.min.isr"
     description: "Overridden min.insync.replicas config for the transaction topic."
     default: "2"
+    trigger: "update"
   - name: TRANSACTIONAL_ID_EXPIRATION_MS
     displayName: "transactional.id.expiration.ms"
     description: "The maximum amount of time in ms that the transaction coordinator will wait before proactively expire a producer's transactional id without receiving any transaction status updates from it."
     default: "604800000"
+    trigger: "update"
   - name: ZOOKEEPER_SYNC_TIME_MS
     displayName: "zookeeper.sync.time.ms"
     description: "How far a ZK follower can be behind a ZK leader"
     default: "2000"
+    trigger: "update"
   - name: TRANSPORT_ENCRYPTION_ENABLED
     displayName: "Enable transport encryption (TLS)"
     description: "Enable transport encryption (TLS)"
     default: "false"
+    trigger: "update"
   - name: TRANSPORT_ENCRYPTION_CIPHERS
     displayName: "Cipher Suite Names"
     description: "Comma-separated list of JSSE Cipher Suite Names"
     default: "TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+    trigger: "update"
   - name: TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT
     displayName: "Allow Plaintext Traffic"
     description: "Allow plaintext alongside encrypted traffic"
     default: "false"
+    trigger: "update"
   - name: SSL_AUTHENTICATION_ENABLED
     displayName: "Enable SSL authentication"
     description: "Enable SSL authentication"
     default: "false"
+    trigger: "update"
   - name: TLS_SECRET_NAME
     default: "kafka-tls"
     displayName: "kafka-tls"
+    trigger: "update"
   - name: USE_AUTO_TLS_CERTIFICATE
     default: "false"
     displayName: "kafka-auto-tls"
@@ -649,10 +803,12 @@ parameters:
     displayName: "custom server properties configmap name"
     description: "The properties present in this configmap will be appended to the Kafka server properties"
     required: false
+    trigger: "update"
   - name: CUSTOM_METRICS_CM_NAME
     displayName: "custom metrics properties and rules"
     description: "These metrics prometheus rules to be used instead of the default metrics rules."
     required: false
+    trigger: "update"
   - name: MIRROR_MAKER_ENABLED
     default: "false"
     trigger: "mirrormaker"
@@ -684,12 +840,16 @@ parameters:
   - name: MIRROR_MAKER_CPUS
     description: "CPUs (request) for the Mirror Maker pods. spec.containers[].resources.requests.cpu"
     default: "100m"
+    trigger: "mirrormaker"
   - name: MIRROR_MAKER_CPUS_LIMIT
     description: "CPUs (limit) for the Mirror Maker pods. spec.containers[].resources.limits.cpu"
     default: "100m"
+    trigger: "mirrormaker"
   - name: MIRROR_MAKER_MEM
     description: "Memory (request) for the Mirror Maker pods. spec.containers[].resources.requests.memory"
     default: "512Mi"
+    trigger: "mirrormaker"
   - name: MIRROR_MAKER_MEM_LIMIT
     description: "Memory (limit) for the Mirror Maker pods. spec.containers[].resources.limits.memory"
     default: "512Mi"
+    trigger: "mirrormaker"

--- a/repository/kafka/operator/templates/cert-generator.yaml
+++ b/repository/kafka/operator/templates/cert-generator.yaml
@@ -6,10 +6,18 @@ spec:
     emptyDir: {}
   initContainers:
     - name: init
+      {{ if eq .Params.USE_AUTO_TLS_CERTIFICATE "true" }}
       image: mesosphere/kafka:1.1.0-2.4.0
+      {{ else }}
+      image: busybox:1.31.1
+      {{ end }}
       command: [ "/bin/sh", "-c" ]
       args:
+        {{ if eq .Params.USE_AUTO_TLS_CERTIFICATE "true" }}
         - openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=KudoKafkaCA" -days 365
+        {{ else }}
+        - touch /tmp/tls.key && touch /tmp/tls.crt
+        {{ end }}
       volumeMounts:
         - name: cert-out
           mountPath: /tmp

--- a/repository/kafka/operator/templates/clusterrole.yaml
+++ b/repository/kafka/operator/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{ if eq .Params.EXTERNAL_ADVERTISED_LISTENER "true" }}
 {{ if eq  .Params.EXTERNAL_ADVERTISED_LISTENER_TYPE "NodePort" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -8,5 +7,4 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]
-{{ end }}
 {{ end }}

--- a/repository/kafka/operator/templates/clusterrolebinding.yaml
+++ b/repository/kafka/operator/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{ if eq .Params.EXTERNAL_ADVERTISED_LISTENER "true" }}
 {{ if eq  .Params.EXTERNAL_ADVERTISED_LISTENER_TYPE "NodePort" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -12,5 +11,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Name }}
   namespace: {{ .Namespace }}
-{{ end }}
 {{ end }}

--- a/repository/kafka/operator/templates/external-service.yaml
+++ b/repository/kafka/operator/templates/external-service.yaml
@@ -1,27 +1,26 @@
 {{ if eq .Params.EXTERNAL_ADVERTISED_LISTENER "true" }}
-{{- $root := . -}}
 {{ range $i, $v := until (int .Params.BROKER_COUNT) }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $root.Name }}-kafka-{{ $v }}-external
-  namespace: {{ $root.Namespace }}
+  name: {{ $.Name }}-kafka-{{ $v }}-external
+  namespace: {{ $.Namespace }}
 spec:
-  type: {{ $root.Params.EXTERNAL_ADVERTISED_LISTENER_TYPE }}
+  type: {{ $.Params.EXTERNAL_ADVERTISED_LISTENER_TYPE }}
   externalTrafficPolicy: Local
   selector:
-    statefulset.kubernetes.io/pod-name: {{ $root.Name }}-kafka-{{ $v }}
+    statefulset.kubernetes.io/pod-name: {{ $.Name }}-kafka-{{ $v }}
   ports:
   - protocol: TCP
-    {{ if eq  $root.Params.EXTERNAL_ADVERTISED_LISTENER_TYPE "LoadBalancer" }}
-    port: {{ $root.Params.EXTERNAL_ADVERTISED_LISTENER_PORT }}
-    targetPort: {{ $root.Params.EXTERNAL_ADVERTISED_LISTENER_PORT }}
+    {{ if eq  $.Params.EXTERNAL_ADVERTISED_LISTENER_TYPE "LoadBalancer" }}
+    port: {{ $.Params.EXTERNAL_ADVERTISED_LISTENER_PORT }}
+    targetPort: {{ $.Params.EXTERNAL_ADVERTISED_LISTENER_PORT }}
     {{ end }}
-    {{ if eq  $root.Params.EXTERNAL_ADVERTISED_LISTENER_TYPE "NodePort" }}
-    port: {{ add (int $root.Params.EXTERNAL_NODE_PORT) $v }}
-    targetPort: {{ add (int $root.Params.EXTERNAL_NODE_PORT) $v }}
-    nodePort: {{ add (int $root.Params.EXTERNAL_NODE_PORT) $v }}
+    {{ if eq  $.Params.EXTERNAL_ADVERTISED_LISTENER_TYPE "NodePort" }}
+    port: {{ add (int $.Params.EXTERNAL_NODE_PORT) $v }}
+    targetPort: {{ add (int $.Params.EXTERNAL_NODE_PORT) $v }}
+    nodePort: {{ add (int $.Params.EXTERNAL_NODE_PORT) $v }}
     {{ end }}
 {{ end }}
 {{ end }}

--- a/repository/kafka/operator/templates/mirror-maker-config.yaml
+++ b/repository/kafka/operator/templates/mirror-maker-config.yaml
@@ -1,4 +1,3 @@
-{{ if eq .Params.MIRROR_MAKER_ENABLED "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,4 +30,3 @@ data:
     group.id={{ .Name }}_mirror_maker_consumer
     auto.offset.reset=earliest
     {{ end }}
-{{ end }}

--- a/repository/kafka/operator/templates/mirror-maker.yaml
+++ b/repository/kafka/operator/templates/mirror-maker.yaml
@@ -1,5 +1,4 @@
-{{ if eq .Params.MIRROR_MAKER_ENABLED "true" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Name }}-mirror-maker
@@ -52,4 +51,3 @@ spec:
             name: {{ .Name }}-mirror-maker-config
   strategy:
     type: Recreate
-{{ end }}

--- a/repository/kafka/operator/templates/service-monitor.yaml
+++ b/repository/kafka/operator/templates/service-monitor.yaml
@@ -1,4 +1,6 @@
 {{ if eq .Params.ADD_SERVICE_MONITOR "true" }}
+# service-monitor cannot use toggle task
+# as KUDO Kafka cannot guarantee the third-party CRDs to be present
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/repository/kafka/operator/templates/statefulset.yaml
+++ b/repository/kafka/operator/templates/statefulset.yaml
@@ -102,9 +102,8 @@ spec:
               name: ingress
             {{ end }}
             {{ if eq  .Params.EXTERNAL_ADVERTISED_LISTENER_TYPE "NodePort" }}
-            {{- $root := . -}}
             {{ range $i, $v := until (int .Params.BROKER_COUNT) }}
-            - containerPort: {{ add (int $root.Params.EXTERNAL_NODE_PORT) $v}}
+            - containerPort: {{ add (int $.Params.EXTERNAL_NODE_PORT) $v}}
               name: node-port-{{ $v }}
             {{ end }}
             {{ end }}

--- a/repository/kafka/operator/templates/user-workload.yaml
+++ b/repository/kafka/operator/templates/user-workload.yaml
@@ -1,5 +1,4 @@
-{{ if eq .Params.RUN_USER_WORKLOAD "true" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Name }}-user-workload-producer
@@ -45,7 +44,7 @@ spec:
   strategy:
     type: Recreate
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Name }}-user-workload-consumer
@@ -86,4 +85,3 @@ spec:
             memory: 512Mi
   strategy:
     type: Recreate
-{{ end }}


### PR DESCRIPTION
this PR:

- add Toggle task for all features present in KUDO Kafka
- update the minimal KUDO version to 0.11.0 because of Toggle Task usage
- add a section of planned releases in `README.md` for unreleased versions to avoid any confusion 
- separate `deploy` and `update` plans, to avoid running pipe task in each update. This should also reduce the test duration in all CI pipelines
- modify the autoTLS feature so it only generates certs when enabled 
- migrate mirrormaker and user workload to use `apps/v1` 
- remove the usage of `$root` as https://github.com/kudobuilder/kudo/pull/1255 was merged and released