### PR TITLE
add kubernetes 1.17 in CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,15 @@ jobs:
       - run: make KUBERNETES_VERSION=<< parameters.kubernetes_version >> test
 
 workflows:
+  test-1.17:
+    jobs:
+      - test:
+          kubernetes_version: 1.17.0
   test-1.16:
     jobs:
       - test:
           kubernetes_version: 1.16.0
-
   test-1.15:
     jobs:
-    - test:
-        kubernetes_version: 1.15.0
+      - test:
+          kubernetes_version: 1.15.0

--- a/test/kind/kubernetes-1.17.0.yaml
+++ b/test/kind/kubernetes-1.17.0.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+  image: kindest/node:v1.17.0


### PR DESCRIPTION
adding kubernetes `1.17` to our builds and as for now keeping `1.15` 

Signed-off-by: Zain Malik <zmalikshxil@gmail.com>