### PR TITLE
drop using startKUDO in kudo-test.yaml

### DIFF
--- a/kudo-test.yaml
+++ b/kudo-test.yaml
@@ -2,27 +2,26 @@ apiVersion: kudo.dev/v1alpha1
 kind: TestSuite
 manifestDirs:
 - ./test/manifests/
-kubectl:
-- kudo init --crd-only
-- kudo install --skip-instance ./repository/cassandra/3.11/operator/
-- kudo install --skip-instance ./repository/confluent-rest-proxy/operator/
-- kudo install --skip-instance ./repository/confluent-schema-registry/operator/
-- kudo install --skip-instance ./repository/cowsay/operator/
-- kudo install --skip-instance ./repository/elastic/operator/
-- kudo install --skip-instance ./repository/first-operator/operator/
-- kudo install --skip-instance ./repository/flink/docs/demo/financial-fraud/demo-operator/
-- kudo install --skip-instance ./repository/flink/operator/
-- kudo install --skip-instance ./repository/kafka/operator/
-- kudo install --skip-instance ./repository/mysql/operator/
-- kudo install --skip-instance ./repository/rabbitmq/operator/
-- kudo install --skip-instance ./repository/redis/operator/
-- kudo install --skip-instance ./repository/spark/operator/
-- kudo install --skip-instance ./repository/zookeeper/operator/
-- kudo install --skip-instance ./templates/akka/operator-shoppingcart/
-- kudo install --skip-instance ./templates/akka/operator/
+commands:
+- command: kubectl kudo init
+- command: kubectl kudo install --skip-instance ./repository/cassandra/3.11/operator/
+- command: kubectl kudo install --skip-instance ./repository/confluent-rest-proxy/operator/
+- command: kubectl kudo install --skip-instance ./repository/confluent-schema-registry/operator/
+- command: kubectl kudo install --skip-instance ./repository/cowsay/operator/
+- command: kubectl kudo install --skip-instance ./repository/elastic/operator/
+- command: kubectl kudo install --skip-instance ./repository/first-operator/operator/
+- command: kubectl kudo install --skip-instance ./repository/flink/docs/demo/financial-fraud/demo-operator/
+- command: kubectl kudo install --skip-instance ./repository/flink/operator/
+- command: kubectl kudo install --skip-instance ./repository/kafka/operator/
+- command: kubectl kudo install --skip-instance ./repository/mysql/operator/
+- command: kubectl kudo install --skip-instance ./repository/rabbitmq/operator/
+- command: kubectl kudo install --skip-instance ./repository/redis/operator/
+- command: kubectl kudo install --skip-instance ./repository/spark/operator/
+- command: kubectl kudo install --skip-instance ./repository/zookeeper/operator/
+- command: kubectl kudo install --skip-instance ./templates/akka/operator-shoppingcart/
+- command: kubectl kudo install --skip-instance ./templates/akka/operator/
 testDirs:
 - ./repository/zookeeper/tests
 - ./repository/kafka/tests
 startKIND: true
-startKUDO: true
 timeout: 300


### PR DESCRIPTION
also use commands instead of kubectl steps, as that will be deprecated from kuttl

`startKUDO` is removed from the kuttl already https://github.com/kudobuilder/kuttl/pull/22
in order to successfully migrate this repo to use kuttl, this PR adapts the kudo-test.yaml so its compatible with kuttl. 

Signed-off-by: Zain Malik <zmalikshxil@gmail.com>