### PR TITLE
fixing website broken links

### DIFF
--- a/repository/cassandra/3.11/docs/installing.md
+++ b/repository/cassandra/3.11/docs/installing.md
@@ -151,11 +151,6 @@ Use HELP for help.
 cqlsh>
 ```
 
-Check out the [parameters reference](./parameters.md) for a complete list of all
-configurable settings.
+Check out the [parameters reference](./parameters.md) for a complete list of all configurable settings.
 
-Check out the
-["configuration" section in the "managing" page](./managing.md#configuration)
-for help with changing an existing operator instance's parameters and the
-[operating](./operating.md) page for help with managing Cassandra operators and
-their underlying Cassandra clusters.
+For help with changing an existing operator instance's parameters and the [managing](./managing.md#updating-parameters) page for help with managing Cassandra operators and their underlying Cassandra clusters.

--- a/repository/cassandra/3.11/docs/managing.md
+++ b/repository/cassandra/3.11/docs/managing.md
@@ -11,7 +11,7 @@
   - [Pod container logs](#pod-container-logs)
   - [Describe pod](#describe-pod)
   - [Cassandra nodetool status](#cassandra-nodetool-status)
-  - [KUDO controller/manager logs](#kudo-controllermanager-logs)
+  - [KUDO controller/manager logs](#kudo-controller-manager-logs)
   - [Get endpoints](#get-endpoints)
   - [Kubernetes events in the instance namespace](#kubernetes-events-in-the-instance-namespace)
 - [Uninstall an operator instance](#uninstall-an-operator-instance)

--- a/repository/kafka/docs/latest/concepts.md
+++ b/repository/kafka/docs/latest/concepts.md
@@ -1,6 +1,6 @@
 # KUDO Kafka Concepts
 
-KUDO Kafka is a Kubernetes operator built on top of [KUDO](kudo.dev) and requires KUDO
+KUDO Kafka is a Kubernetes operator built on top of [KUDO](http://kudo.dev) and requires KUDO
 
 #### KUDO Kafka CRDs
 
@@ -16,15 +16,14 @@ The KUDO controller continually watches the Operator, OperatorVersion and Instan
 
 ![kudo-kafka](./resources/images/kudo-controller-kafka.png)
 
-When a user installs KUDO Kafka using the `kudo-cli`, the controller creates the KUDO Kafka CRDs for Operator, OperatorVersion and Instance. More information can be read in [KUDO Architecture](https://kudo.dev/docs/architecture.html#architecture-diagram) 
+When a user installs KUDO Kafka using the `kudo-cli`, the controller creates the KUDO Kafka CRDs for Operator, OperatorVersion and Instance. More information can be read in [KUDO Architecture](https://kudo.dev/docs/architecture.html#architecture-diagram)
 
 ![kudo-kafka](./resources/images/kudo-installs-kafka.png)
 
-When the KUDO Controller detects a new `Instance`, it creates all the resources required to reach the desired state of the configuration. 
+When the KUDO Controller detects a new `Instance`, it creates all the resources required to reach the desired state of the configuration.
 
 ![kudo-kafka](./resources/images/kafka-cluster.png)
 
 The same process is followed for any updates or deletions. Everything is handled by the KUDO Controller.
 
 ![kudo-kafka](./resources/images/kudo-update-kafka.png)
-

--- a/repository/spark/docs/latest/configuration.md
+++ b/repository/spark/docs/latest/configuration.md
@@ -9,7 +9,7 @@ The default KUDO Spark configuration enables installation of the following resou
 * Mutating Admission Webhook for customizing Spark driver and executor pods based on the specification
 * `MetricsService` for Spark Operator and Spark Applications to enable metrics scraping by Prometheus
 
-Full list of configuration parameters and defaults is available in KUDO Spark [params.yaml](../../operator/params.yaml).
+Full list of configuration parameters and defaults is available in KUDO Spark [params.yaml](https://github.com/kudobuilder/operators/blob/master/repository/spark/operator/params.yaml).
 ## Docker
 Docker images used by KUDO Spark and image pull policy can be specified by providing the following parameters:
 ```bash
@@ -65,15 +65,15 @@ kubectl kudo install spark --instance=spark-operator -p createRBAC=<true|false>
 ```
 
 KUDO Spark requires a `ClusterRole` to be configured in order for it to handle custom resources, listen to events, work
-with secrets, configmaps, and services. The full list of permissions is available in [spark-operator-rbac.yaml](../../operator/templates/spark-operator-rbac.yaml).
-If `createRBAC` parameter is set to `false`, a `ClusterRole` and `ClusterRoleBinding` should be created or exist before 
-the installation. `ClusterRoleBinding` should be linked to the Service Account used by the Operator. 
+with secrets, configmaps, and services. The full list of permissions is available in [spark-operator-rbac.yaml](https://github.com/kudobuilder/operators/blob/master/repository/spark/operator/templates/spark-operator-rbac.yaml).
+If `createRBAC` parameter is set to `false`, a `ClusterRole` and `ClusterRoleBinding` should be created or exist before
+the installation. `ClusterRoleBinding` should be linked to the Service Account used by the Operator.
 
 Spark Applications submitted to KUDO Spark also require permissions to launch Spark Executors and monitor their state. For this
 purpose KUDO Spark creates a `Role` for them and binds it to a service account provided via `-p sparkServiceAccountName=<service account name>`.
 If `createRBAC` flag is set to `false`, a `Role` (with a `RoleBinding` linked to Spark Service Account) should be
 created or exist prior to submission of Spark Applications. `Role` configuration and a list of required permissions are
-available in [spark-rbac.yaml](../../operator/templates/spark-rbac.yaml) template file.
+available in [spark-rbac.yaml](https://github.com/kudobuilder/operators/blob/master/repository/spark/operator/templates/spark-rbac.yaml) template file.
 
 ### Integration with AWS S3
 This section describes the steps required for configuring secure access to S3 buckets for Spark workloads and Spark History server.
@@ -102,7 +102,7 @@ Note: a Secret must be in the same namespace as an Spark Operator.
 
 To read more about Secrets, refer to the [official K8s documentation](https://kubernetes.io/docs/concepts/configuration/secret/).
 
-Here is an example configuration which uses a `Secret` to pass AWS credentials as environment variables to `SparkApplication`: 
+Here is an example configuration which uses a `Secret` to pass AWS credentials as environment variables to `SparkApplication`:
 ```yaml
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
@@ -135,4 +135,4 @@ spec:
             name: aws-credentials
             key: AWS_SESSION_TOKEN
             optional: true
-``` 
+```

--- a/repository/spark/docs/latest/monitoring.md
+++ b/repository/spark/docs/latest/monitoring.md
@@ -3,8 +3,8 @@
 KUDO Spark Operator has metrics reporting support, which can be enabled during the installation of the operator.  
 By default, it supports integration with the [Prometheus operator](https://github.com/coreos/prometheus-operator).
 
-Prometheus Operator relies on `ServiceMonitor` kind which describes the set of targets to be monitored. 
-KUDO Spark Operator configures `ServiceMonitor`s for both the Operator and submitted Spark Applications automatically 
+Prometheus Operator relies on `ServiceMonitor` kind which describes the set of targets to be monitored.
+KUDO Spark Operator configures `ServiceMonitor`s for both the Operator and submitted Spark Applications automatically
 when monitoring is enabled.
 
 #### Exporting Spark Operator and Spark Application metrics to Prometheus
@@ -24,7 +24,7 @@ $ kubectl kudo install spark --instance=spark -p enableMetrics=true
 Service endpoints and ServiceMonitor resources are configured to work with Prometheus Operator
 out of the box.
 
-Full list of metrics configuration parameters and defaults is available in KUDO Spark [params.yaml](../../operator/params.yaml).
+Full list of metrics configuration parameters and defaults is available in KUDO Spark [params.yaml](https://github.com/kudobuilder/operators/blob/master/repository/spark/operator/params.yaml).
 
 ##### Running Spark Application with metrics enabled
 1) Composing your Spark Application yaml:
@@ -41,7 +41,7 @@ Full list of metrics configuration parameters and defaults is available in KUDO 
      `spec.momitoring.prometheus.port` value should be the same for all submitted Spark Applications in order for metrics to be scraped.
    - if it's necessary to expose the metrics endpoint on a port other than `8090`, do the following:
      - specify desired port when installing the `kudo-spark-operator`:  
- 
+
      ```
      kubectl kudo install spark -p appMetricsPort=<desired_port>
      ```
@@ -61,16 +61,16 @@ Full list of metrics configuration parameters and defaults is available in KUDO 
      kubectl apply -f <path_to_the_application_yaml>   
      ```
    Full application configuration example is available in [spark-application-with-metrics.yaml](resources/monitoring/spark-application-with-metrics.yaml)
-1) Now, go to the prometheus dashboard (e.g. `<kubernetes_endpoint_url>/ops/portal/prometheus/graph`) and search for metrics 
-starting with 'spark'. The Prometheus URI might be different depending on how you configured and installed the `prometheus-operator`. 
+1) Now, go to the prometheus dashboard (e.g. `<kubernetes_endpoint_url>/ops/portal/prometheus/graph`) and search for metrics
+starting with 'spark'. The Prometheus URI might be different depending on how you configured and installed the `prometheus-operator`.
 
 #### Dashboards
- * [Spark Applications Dashboard](resources/dashboards/grafana_spark_applications.json) 
+ * [Spark Applications Dashboard](resources/dashboards/grafana_spark_applications.json)
  * [Spark Operator Dashboard](resources/dashboards/grafana_spark_operator.json)
- 
- Dashboard installation : 
+
+ Dashboard installation :
 1) Open the Grafana site (e.g. `<kubernetes_endpoint_url>/ops/portal/grafana`).  
 1) Press + button and pick `Import` item from the menu.  
-1) Copy content of the dashboard json file and paste it to the textarea on importing form. 
+1) Copy content of the dashboard json file and paste it to the textarea on importing form.
 
-For more information visit Grafana documentation: [Importing a dashboard guide](https://grafana.com/docs/reference/export_import/#importing-a-dashboard). 
+For more information visit Grafana documentation: [Importing a dashboard guide](https://grafana.com/docs/reference/export_import/#importing-a-dashboard).


### PR DESCRIPTION
There are a number of items for which there wasn't a clear path... the referenced document doesn't exist.
Very important for these operator docs, is that they are embedded into our kudo.dev website.  There are links which would work within the repository (`../../operator/` as example) which fail on the website.  We need to make sure that links in the repository work on the website.

Signed-off-by: Ken Sipe <kensipe@gmail.com>