### PR TITLE
[KAFKA] Add support for max.incremental.fetch.session.cache.slots

### DIFF
--- a/repository/kafka/operator/params.yaml
+++ b/repository/kafka/operator/params.yaml
@@ -673,6 +673,11 @@ parameters:
     description: "Per-ip or hostname overrides to the default maximum number of connections"
     default: ""
     trigger: "update"
+  - name: MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS
+    displayName: "max.incremental.fetch.session.cache.slots"
+    description: "Per-ip or hostname overrides to the default maximum number of connections"
+    default: "1000"
+    trigger: "update"
   - name: PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS
     displayName: "producer.purgatory.purge.interval.requests"
     description: "The purge interval (in number of requests) of the producer request purgatory"

--- a/repository/kafka/operator/templates/server.properties.yaml
+++ b/repository/kafka/operator/templates/server.properties.yaml
@@ -221,6 +221,8 @@ data:
     max.connections.per.ip.overrides={{ .Params.MAX_CONNECTIONS_PER_IP_OVERRIDES }}
     max.connections.per.ip={{ .Params.MAX_CONNECTIONS_PER_IP }}
 
+    max.incremental.fetch.session.cache.slots={{ .Params.MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS }}
+
     message.max.bytes={{ .Params.MESSAGE_MAX_BYTES }}
 
     metric.reporters={{ .Params.METRIC_REPORTERS }}


### PR DESCRIPTION
A user requested configureable support for `max.incremental.fetch.session.cache.slots` in [dcos-kafka](https://github.com/mesosphere/dcos-kafka-service/pull/461) adding it here for parity.