### PR TITLE
spark: fix typos in the docs

### DIFF
--- a/repository/spark/docs/2.4.4-0.2.0/advanced-configuration.md
+++ b/repository/spark/docs/2.4.4-0.2.0/advanced-configuration.md
@@ -6,7 +6,7 @@ Advanced configuration options
 Spark Operator supports high-availability (HA) deployment mode when more than one replica of operator pod is deployed and [leader election](https://en.wikipedia.org/wiki/Leader_election) is enabled. 
 
 In this mode, only one replica (leader) of operator deployment is actively operating 
-(handling updates of resources with kind `SparkApplpication` which represent Spark jobs submitted to a cluster), while other replicas are idle.
+(handling updates of resources with kind `SparkApplication` which represent Spark jobs submitted to a cluster), while other replicas are idle.
 
 ![](resources/img/ha.png)
 

--- a/repository/spark/docs/2.4.5-1.0.0/advanced-configuration.md
+++ b/repository/spark/docs/2.4.5-1.0.0/advanced-configuration.md
@@ -5,7 +5,7 @@
 Spark Operator supports high-availability (HA) deployment mode when more than one replica of operator pod is deployed and [leader election](https://en.wikipedia.org/wiki/Leader_election) is enabled. 
 
 In this mode, only one replica (leader) of operator deployment is actively operating 
-(handling updates of resources with kind `SparkApplpication` which represent Spark jobs submitted to a cluster), while other replicas are idle.
+(handling updates of resources with kind `SparkApplication` which represent Spark jobs submitted to a cluster), while other replicas are idle.
 
 ![](resources/img/ha.png)
 

--- a/repository/spark/docs/latest/advanced-configuration.md
+++ b/repository/spark/docs/latest/advanced-configuration.md
@@ -5,7 +5,7 @@
 Spark Operator supports high-availability (HA) deployment mode when more than one replica of operator pod is deployed and [leader election](https://en.wikipedia.org/wiki/Leader_election) is enabled. 
 
 In this mode, only one replica (leader) of operator deployment is actively operating 
-(handling updates of resources with kind `SparkApplpication` which represent Spark jobs submitted to a cluster), while other replicas are idle.
+(handling updates of resources with kind `SparkApplication` which represent Spark jobs submitted to a cluster), while other replicas are idle.
 
 ![](resources/img/ha.png)
 


### PR DESCRIPTION
Fixed a few typos related to `SparkApplication`.

Signed-off-by: Jie Yu <yujie.jay@gmail.com>