### PR TITLE
Fix name prefixes in the Elastic operator

### DIFF
--- a/repository/elastic/operator/operator.yaml
+++ b/repository/elastic/operator/operator.yaml
@@ -1,6 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 name: "elastic"
-operatorVersion: "0.2.0"
+operatorVersion: "0.2.1"
 kudoVersion: 0.10.0
 kubernetesVersion: 1.15.0
 appVersion: 7.0.0

--- a/repository/elastic/operator/templates/coordinator-service.yaml
+++ b/repository/elastic/operator/templates/coordinator-service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: coordinator-hs
+  name: {{ .Name }}-coordinator-hs
   namespace: {{ .Namespace }}
 spec:
   selector:

--- a/repository/elastic/operator/templates/coordinator.yaml
+++ b/repository/elastic/operator/templates/coordinator.yaml
@@ -1,7 +1,7 @@
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: coordinator
+  name: {{ .Name }}-coordinator
   namespace: {{ .Namespace }}
 spec:
   selector:

--- a/repository/elastic/operator/templates/data-service.yaml
+++ b/repository/elastic/operator/templates/data-service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: data-hs
+  name: {{ .Name }}-data-hs
   namespace: {{ .Namespace }}
 spec:
   selector:

--- a/repository/elastic/operator/templates/data.yaml
+++ b/repository/elastic/operator/templates/data.yaml
@@ -1,7 +1,7 @@
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: data
+  name: {{ .Name }}-data
   namespace: {{ .Namespace }}
 spec:
   selector:

--- a/repository/elastic/operator/templates/ingest-service.yaml
+++ b/repository/elastic/operator/templates/ingest-service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: ingest-hs
+  name: {{ .Name }}-ingest-hs
   namespace: {{ .Namespace }}
 spec:
   selector:

--- a/repository/elastic/operator/templates/ingest.yaml
+++ b/repository/elastic/operator/templates/ingest.yaml
@@ -1,7 +1,7 @@
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: ingest
+  name: {{ .Name }}-ingest
   namespace: {{ .Namespace }}
 spec:
   selector:

--- a/repository/elastic/operator/templates/master-service.yaml
+++ b/repository/elastic/operator/templates/master-service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: master-hs
+  name: {{ .Name }}-master-hs
   namespace: {{ .Namespace }}
 spec:
   selector:

--- a/repository/elastic/operator/templates/master.yaml
+++ b/repository/elastic/operator/templates/master.yaml
@@ -1,7 +1,7 @@
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: master
+  name: {{ .Name }}-master
   namespace: {{ .Namespace }}
 spec:
   selector:


### PR DESCRIPTION
KUDO doesn't prefix names by itself but the operator was expecting this behavior. The resource definitions have been updated to add a name prefix to them.

Tested by installing the operator with default parameters locally. Checked logs to verify that all pods are resolvable.

Fixes #227 