### PR TITLE
Spark: change `sparkJobNamespace` parameter propagation logic

### DIFF
--- a/repository/spark/docs/latest/installation.md
+++ b/repository/spark/docs/latest/installation.md
@@ -48,9 +48,10 @@ Optionally, create dedicated namespaces for installing KUDO Spark instances(e.g.
 kubectl create ns spark-operator-1 && kubectl create ns spark-operator-2
 ```
 ```
-kubectl kudo install spark --instance=spark-1 --namespace spark-operator-1
-kubectl kudo install spark --instance=spark-2 --namespace spark-operator-2
+kubectl kudo install spark --instance=spark-1 --namespace spark-operator-1 -p sparkJobNamespace=spark-operator-1
+kubectl kudo install spark --instance=spark-2 --namespace spark-operator-2 -p sparkJobNamespace=spark-operator-2
 ```
 
 The above commands will install two Spark Operators in two different namespaces. Spark Applications submitted to a specific
-namespace will be handled by the Operator installed in the same namespace.
+namespace will be handled by the Operator installed in the same namespace. This is achieved by explicitly setting 
+the `sparkJobNamespace` parameter to corresponding operator namespace.

--- a/repository/spark/operator/params.yaml
+++ b/repository/spark/operator/params.yaml
@@ -126,7 +126,7 @@ parameters:
 
   ## Miscellaneous
   - name: sparkJobNamespace
-    description: "Namespace for Spark Applications. Defaults to Operator namespace"
+    description: "Namespace for Spark Applications. By default, Spark Operator will monitor Spark Application across all the namespaces."
     default: ""
     displayName: "Namespace for Spark Applications"
 

--- a/repository/spark/operator/templates/spark-operator-deployment.yaml
+++ b/repository/spark/operator/templates/spark-operator-deployment.yaml
@@ -67,11 +67,7 @@ spec:
         {{ end }}
         args:
         - -v={{ .Params.logLevel }}
-        {{- if (ne .Params.sparkJobNamespace "") }}
         - -namespace={{ .Params.sparkJobNamespace }}
-        {{- else }}
-        - -namespace={{ .Namespace }}
-        {{- end }}
         - -ingress-url-format={{ .Params.ingressUrlFormat }}
         - -controller-threads={{ .Params.controllerThreads }}
         - -resync-interval={{ .Params.resyncIntervalSeconds }}


### PR DESCRIPTION
This PR changes the logic around `sparkJobNamespace` parameter handling to prevent switching to operator namespace by default and pass the original parameter value to operator arguments.
Also, it updates the documentation to reflect the change.

Signed-off-by: Alex Lembiewski <alembiyeuski.c@d2iq.com>