### PR TITLE
Update Spark Operator documentation

### DIFF
--- a/repository/spark/docs/latest/installation.md
+++ b/repository/spark/docs/latest/installation.md
@@ -20,8 +20,8 @@ To install a new instance of Spark operator from the official repository, use th
 ```
 kubectl kudo install spark --namespace spark
 ```
-This will install Spark operator instance with a name `spark-instance` to the provided namespace.
-You can also specify instance name using `--instance` parameter:
+This will install a Spark operator instance with the name `spark-instance` to the provided namespace.
+You can also specify a different instance name using `--instance` parameter:
 
 ```
 kubectl kudo install spark --instance spark-operator --namespace spark

--- a/repository/spark/docs/latest/installation.md
+++ b/repository/spark/docs/latest/installation.md
@@ -12,18 +12,29 @@ Requirements:
 Check out existing [limitations](limitations.md) before installing a KUDO Spark instance. Currently, multi-instance 
 (multi-tenant) operator installation supports only a single instance per namespace. 
 
+Create a namespace for the operator:
 ```
-kubectl kudo install spark --instance=spark
+kubectl create ns spark
+```
+To install a new instance of Spark operator from the official repository, use the following command:
+```
+kubectl kudo install spark --namespace spark
+```
+This will install Spark operator instance with a name `spark-instance` to the provided namespace.
+You can also specify instance name using `--instance` parameter:
+
+```
+kubectl kudo install spark --instance spark-operator --namespace spark
 ```
 
-Verify if the deploy plan for `--instance=spark` is complete:
+Verify if the deploy plan for `--instance spark-instance` is complete:
 ```
-kubectl kudo plan status --instance=spark
+kubectl kudo plan status --instance spark-instance --namespace spark
 
-Plan(s) for "spark" in namespace "default":
+Plan(s) for "spark-instance" in namespace "spark":
 .
-└── spark (Operator-Version: "spark-1.0.1" Active-Plan: "deploy")
-    └── Plan deploy (serial strategy) [COMPLETE], last updated 2020-05-26 15:58:39
+└── spark-instance (Operator-Version: "spark-1.0.1" Active-Plan: "deploy")
+    └── Plan deploy (serial strategy) [COMPLETE], last updated 2020-07-10 12:21:26
         ├── Phase preconditions (serial strategy) [COMPLETE]
         │   ├── Step crds [COMPLETE]
         │   ├── Step service-account [COMPLETE]

--- a/repository/spark/docs/latest/limitations.md
+++ b/repository/spark/docs/latest/limitations.md
@@ -1,9 +1,5 @@
 # Limitations
 
 ## Multi-instance installation
-* Currently, multi-instance (multi-tenant) operator installation supports only a single instance per namespace to
-allow Spark applications be launched in the namespace they've been submitted to. Multiple operator instances
-installed in the same namespace run job submissions in parallel which can potentially lead to race conditions
-and inconsistent application state.
-* Operator instances must have unique names to avoid clashes when `createRBAC` property is set to `true`.
-KUDO Controller will reject new instance installation because it will try to create a `ClusterRole` with the same name.
+* Currently, multi-instance (multi-tenant) operator installation supports only a single instance per namespace to allow Spark applications be launched in the namespace they've been submitted to. Multiple operator instances installed in the same namespace run job submissions in parallel which can potentially lead to race conditions and inconsistent application state.
+* Operator instances must have unique names to avoid clashes when `createRBAC` property is set to `true`. KUDO Controller will reject new instance installation because it will try to create a `ClusterRole` with the same name.

--- a/repository/spark/docs/latest/submission.md
+++ b/repository/spark/docs/latest/submission.md
@@ -22,8 +22,6 @@ spec:
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar"
-  arguments:
-    - "150000"
   sparkConf:
     "spark.ui.port": "4041"
   sparkVersion: "2.4.5"
@@ -34,7 +32,7 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.5
-    serviceAccount: spark-driver
+    serviceAccount: spark-instance-spark-service-account
   executor:
     cores: 1
     instances: 2

--- a/repository/spark/docs/latest/submission.md
+++ b/repository/spark/docs/latest/submission.md
@@ -7,7 +7,7 @@
 
 In order to deploy a Spark Application to Kubernetes using the KUDO Spark Operator, it should be described as a Kubernetes object. To do that, create a specification in `yaml` format with all the necessary configuration required for the application.
 
-Let's take a simple `SparkPi` application as an example. The `yaml` specification could be found here: [spark-pi.yaml](resources/spark-pi.yaml)
+Let's take a simple `SparkPi` application as an example. The `yaml` specification could be found here: [spark-pi.yaml](resources/spark-pi.yaml).  This example assumes that you installed KUDO spark to the `spark` namespace.
 
 ```yaml
 apiVersion: "sparkoperator.k8s.io/v1beta2"
@@ -32,7 +32,7 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.5
-    serviceAccount: spark-instance-spark-service-account
+    serviceAccount: spark-spark-service-account
   executor:
     cores: 1
     instances: 2
@@ -41,7 +41,9 @@ spec:
       version: 2.4.5
 ```
 
-Basically, all the Spark application configuration is placed under `spec` section. Here you can specify Spark related configuration properties, such as number of executors, number of cores for drivers/executors, amount of memory, etc. There is also a `sparkConf` section, where you can place configuration parameters in the form of key-value pairs. In this example, we override the default `spark.ui.port` with a custom value.
+All the Spark application configuration is placed under `spec` section. Here you can specify Spark related configuration properties, such as number of executors, number of cores for drivers/executors, amount of memory, etc. There is also a `sparkConf` section, where you can place configuration parameters in the form of key-value pairs. In this example, we override the default `spark.ui.port` with a custom value.
+
+Crucial to the success of running this Spark job is the `serviceAccount`.  The format for the service account is `{spark-operator name}-spark-service-account`.  If you have installed the spark operator without specifying the instance name, its name will be `spark-instance`, thus the service account name will need to be `spark-instance-spark-service-account`.
 
 #### Creating the application
 


### PR DESCRIPTION
This PR updates the Spark Operator installation doc and also fixes the default service account name used by Spark Driver in 
 SparkApplication example.

Signed-off-by: Alex Lembiewski <alembiyeuski.c@d2iq.com>

