### PR TITLE
Use Kafka Operator 1.3.1 for flink demo

### DIFF
--- a/repository/flink/docs/demo/financial-fraud/demo-operator/operator.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/operator.yaml
@@ -13,7 +13,7 @@ tasks:
     kind: KudoOperator
     spec:
       package: kafka
-      operatorVersion: 1.2.1
+      operatorVersion: 1.3.1
       parameterFile: kafka-params.yaml
       instanceName: kafka
   - name: zookeeper

--- a/repository/flink/docs/demo/financial-fraud/demo-operator/operator.yaml
+++ b/repository/flink/docs/demo/financial-fraud/demo-operator/operator.yaml
@@ -13,7 +13,7 @@ tasks:
     kind: KudoOperator
     spec:
       package: kafka
-      operatorVersion: 1.2.0
+      operatorVersion: 1.2.1
       parameterFile: kafka-params.yaml
       instanceName: kafka
   - name: zookeeper


### PR DESCRIPTION
The new repository does not contain the kafka operator version 1.2.0, to not break things we need to bump this.