### PR TITLE
Fix webhook config name template to handle multi-instance deployments of Spark operator

### DIFF
--- a/repository/spark/operator/templates/spark-operator-deployment.yaml
+++ b/repository/spark/operator/templates/spark-operator-deployment.yaml
@@ -85,7 +85,7 @@ spec:
         - -webhook-svc-namespace={{ .Namespace }}
         - -webhook-port={{ .Params.webhookPort }}
         - -webhook-svc-name={{ .Name }}-webhook
-        - -webhook-config-name={{ .OperatorName }}-webhook-config
+        - -webhook-config-name={{ .Namespace }}-{{ .Name }}-webhook-config
         {{- end }}
         {{- if eq .Params.enableLeaderElection "true" }}
         - -leader-election=true


### PR DESCRIPTION
This PR changes the template for `-webhook-config-name` config parameter to guarantee it is not being overwritten by another operator instance. This way we ensure each operator will have its own webhook configuration and will operate properly within the namespace set via `sparkJobNamespace` parameter.

### How to reproduce

1) Create two namespaces:
```
for index in `seq 2`; do kubectl create ns spark-$index; done
```
2) Install two operator instances:

```
for index in `seq 2`; do kubectl kudo install ./repository/spark/operator  --namespace spark-$index -p sparkJobNamespace=spark-$index; done
```

3) Check webhook configurations:

```
kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io
```

4) Submit the app:
```
cat > spark-pi.yaml <<EOF
apiVersion: "sparkoperator.k8s.io/v1beta2"
kind: SparkApplication
metadata:
  name: spark-pi
spec:
  type: Scala
  mode: cluster
  image: mesosphere/spark-dev:e0f9eb2dcc71b2de6d3e0ce8a0f26c059430b946
  imagePullPolicy: Always
  mainClass: org.apache.spark.examples.SparkPi
  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.0.0.jar"
  arguments:
  - "10"
  sparkConf:
    "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
    "spark.scheduler.minRegisteredResourcesRatio": "1.0"
  sparkVersion: 3.0.0
  restartPolicy:
    type: Never
  driver:
    cores: 1
    memory: "512m"
    labels:
      version: 3.0.0
    serviceAccount: spark-instance-spark-service-account
    env:
    - name: FOO
      value: BAR
  executor:
    cores: 1
    instances: 1
    memory: "512m"
    deleteOnTermination: false
    labels:
      version: 3.0.0
    env:
    - name: FOO
      value: BAR
EOF
```
5) Submit the app to both operators and wait until driver pods are created:
```
for i in `seq 2`; do kubectl apply -f spark-pi.yaml -n spark-$i; done
```
6) Check driver pod specs and verify a pod from `spark-1` doesn't have a `FOO` env variable set (pods haven't been mutated):
```
kubectl get pod spark-pi-driver -o yaml -n spark-1
kubectl get pod spark-pi-driver -o yaml -n spark-2
```

7) kubectl logs -n spark-2 -l spark-instance-<...>

```
...
I0914 12:20:16.407141      11 webhook.go:246] Serving admission request
I0914 12:20:16.407127      11 webhook.go:246] Serving admission request
I0914 12:20:16.433141      11 webhook.go:540] Pod spark-pi-driver in namespace spark-1 is not subject to mutation
I0914 12:20:16.440119      11 webhook.go:556] Pod spark-pi-driver in namespace spark-2 is subject to mutation
...
```
 Because of the overwritten webhook configuration and `sparkJobNamespace` parameter set, the pod from `spark-1` namespace is not being mutated by webhook.


Operators' logs after redeployment with the fix:

`k logs -n spark-1 spark-instance-<...>`
```
...
I0914 13:18:29.310805      11 webhook.go:246] Serving admission request
I0914 13:18:29.315062      11 webhook.go:246] Serving admission request
I0914 13:18:29.331875      11 webhook.go:556] Pod spark-pi-driver in namespace spark-1 is subject to mutation
I0914 13:18:29.342728      11 webhook.go:540] Pod spark-pi-driver in namespace spark-2 is not subject to mutation
I0914 13:18:29.425951      11 spark_pod_eventhandler.go:47] Pod spark-pi-driver added in namespace spark-1.
I0914 13:18:29.464859      11 spark_pod_eventhandler.go:58] Pod spark-pi-driver updated in namespace spark-1.
I0914 13:18:29.553143      11 spark_pod_eventhandler.go:58] Pod spark-pi-driver updated in namespace spark-1.
...
```
`k logs -n spark-2 spark-instance-<...>`
```
...
I0914 13:18:29.359774      10 webhook.go:246] Serving admission request
I0914 13:18:29.361754      10 webhook.go:246] Serving admission request
I0914 13:18:29.364741      10 webhook.go:556] Pod spark-pi-driver in namespace spark-2 is subject to mutation
I0914 13:18:29.365795      10 webhook.go:540] Pod spark-pi-driver in namespace spark-1 is not subject to mutation
I0914 13:18:29.490842      10 spark_pod_eventhandler.go:47] Pod spark-pi-driver added in namespace spark-2.
I0914 13:18:29.490908      10 spark_pod_eventhandler.go:58] Pod spark-pi-driver updated in namespace spark-2.
I0914 13:18:29.504636      10 spark_pod_eventhandler.go:58] Pod spark-pi-driver updated in namespace spark-2.
...
```

Signed-off-by: Alex Lembiewski <alembiyeuski.c@d2iq.com>