### PR TITLE
Zookeeper: Make the image pull policy configurable

### DIFF
--- a/repository/zookeeper/README.md
+++ b/repository/zookeeper/README.md
@@ -4,11 +4,12 @@ The KUDO Zookeeper operator creates, configures and manages [Apache Zookeeper](h
 
 ## Getting started
 
-The latest stable version of Zookeeper operator is `0.3.0`
+The latest stable version of Zookeeper operator is `0.3.1`
 
 ## Version Chart
 
 | KUDO Zookeeper Version | Apache Zookeeper Version |
 | ---------------------- | ------------------------ |
+| 0.3.1                  | 3.4.14                   |
 | 0.3.0                  | 3.4.14                   |
 | latest                 | 3.4.14                   |

--- a/repository/zookeeper/operator/operator.yaml
+++ b/repository/zookeeper/operator/operator.yaml
@@ -1,6 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 name: "zookeeper"
-operatorVersion: "0.3.1"
+operatorVersion: "0.3.2"
 kudoVersion: 0.10.0
 appVersion: 3.4.14
 kubernetesVersion: 1.14.8

--- a/repository/zookeeper/operator/params.yaml
+++ b/repository/zookeeper/operator/params.yaml
@@ -37,3 +37,6 @@ parameters:
     description: |
       The port on which the Zookeeper process will perform leader election. The default is 3888.
     default: "3888"
+  - name: IMAGE_PULL_POLICY
+    description: "Zookeeper container image pull policy"
+    default: "Always"

--- a/repository/zookeeper/operator/templates/statefulset.yaml
+++ b/repository/zookeeper/operator/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: kubernetes-zookeeper
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Params.IMAGE_PULL_POLICY }}
           image: "zookeeper:3.4.14"
           resources:
             requests:

--- a/repository/zookeeper/operator/templates/validation.yaml
+++ b/repository/zookeeper/operator/templates/validation.yaml
@@ -10,7 +10,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: kubernetes-zookeeper
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Params.IMAGE_PULL_POLICY }}
           image: "zookeeper:3.4.14"
           env:
             - name: CONN


### PR DESCRIPTION
This adds parameters to allow users to change the image pull policy of the container image used by the operator.

Fixes: #247 