### PR TITLE
[D2IQ-73247] Adds missing parameter in comparison to DCOS Cassandra

### DIFF
--- a/repository/cassandra/3.11/operator/params.yaml
+++ b/repository/cassandra/3.11/operator/params.yaml
@@ -389,6 +389,10 @@ parameters:
   - name: CREDENTIALS_UPDATE_INTERVAL_IN_MS
     description: "After this interval, cache entries become eligible for refresh. The next time the cache is accessed, the system schedules an asynchronous reload of the cache. Until this cache reload is complete, the cache returns the old values. If credentials_validity_in_ms is nonzero, this property must also be nonzero."
     default: ""
+  
+  - name: PERMISSIONS_CACHE_MAX_ENTRIES
+    description: "The maximum number of entries that are held by the standard authentication cache and row-level access control (RLAC) cache."
+    default: "1000"
 
   - name: PERMISSIONS_VALIDITY_IN_MS
     description: "How many milliseconds permissions in cache remain valid. Fetching permissions can be resource intensive. To disable the cache, set this to 0."

--- a/repository/cassandra/3.11/operator/templates/generate-cassandra-yaml.yaml
+++ b/repository/cassandra/3.11/operator/templates/generate-cassandra-yaml.yaml
@@ -240,6 +240,15 @@ data:
     permissions_update_interval_in_ms: {{ .Params.PERMISSIONS_UPDATE_INTERVAL_IN_MS }}
     {{ end }}
 
+    # The maximum number of entries that are held by the standard authentication
+    # cache and row-level access control (RLAC) cache. With the default value of 1000,
+    # the RLAC permissions cache can have up to 1000 entries in it, and the standard
+    # authentication cache can have up to 1000 entries. This single option applies to
+    # both caches.
+    {{ if .Params.PERMISSIONS_CACHE_MAX_ENTRIES }}
+    permissions_cache_max_entries: {{ .Params.PERMISSIONS_CACHE_MAX_ENTRIES }}
+    {{ end }}
+
     # Validity period for credentials cache. This cache is tightly coupled to
     # the provided PasswordAuthenticator implementation of IAuthenticator. If
     # another IAuthenticator implementation is configured, this cache will not


### PR DESCRIPTION
Jira Ticket: [D2IQ-73247](https://jira.d2iq.com/browse/D2IQ-73247)

This PR adds a parameter to the Cassandra Operator, which is not present in the Kudo Cassandra, but present in the DC/OS Cassandra.