### PR TITLE
Upgrade to zookeeper 3.6.2

### DIFF
--- a/repository/zookeeper/README.md
+++ b/repository/zookeeper/README.md
@@ -4,7 +4,7 @@ The KUDO Zookeeper operator creates, configures and manages [Apache Zookeeper](h
 
 ## Getting started
 
-The latest stable version of Zookeeper operator is `0.3.2`
+The latest stable version of Zookeeper operator is `0.3.3`
 
 ## Version Chart
 

--- a/repository/zookeeper/README.md
+++ b/repository/zookeeper/README.md
@@ -4,12 +4,14 @@ The KUDO Zookeeper operator creates, configures and manages [Apache Zookeeper](h
 
 ## Getting started
 
-The latest stable version of Zookeeper operator is `0.3.1`
+The latest stable version of Zookeeper operator is `0.3.2`
 
 ## Version Chart
 
 | KUDO Zookeeper Version | Apache Zookeeper Version |
 | ---------------------- | ------------------------ |
+| 0.3.3                  | 3.6.2                    |
+| 0.3.2                  | 3.4.14                   |
 | 0.3.1                  | 3.4.14                   |
 | 0.3.0                  | 3.4.14                   |
-| latest                 | 3.4.14                   |
+| latest                 | 3.6.2                    |

--- a/repository/zookeeper/operator/operator.yaml
+++ b/repository/zookeeper/operator/operator.yaml
@@ -1,8 +1,8 @@
 apiVersion: kudo.dev/v1beta1
 name: "zookeeper"
-operatorVersion: "0.3.2"
+operatorVersion: "0.3.3"
 kudoVersion: 0.10.0
-appVersion: 3.4.14
+appVersion: 3.6.2
 kubernetesVersion: 1.14.8
 maintainers:
   - name: Alena Varkockova

--- a/repository/zookeeper/operator/templates/bootstrap.sh.yaml
+++ b/repository/zookeeper/operator/templates/bootstrap.sh.yaml
@@ -192,6 +192,7 @@ data:
     maxSessionTimeout=$MAX_SESSION_TIMEOUT
     autopurge.snapRetainCount=$SNAP_RETAIN_COUNT
     autopurge.purgeInteval=$PURGE_INTERVAL
+    4lw.commands.whitelist=srvr, ruok
 
     EOF
         if [ $SERVERS -gt 1 ]; then

--- a/repository/zookeeper/operator/templates/statefulset.yaml
+++ b/repository/zookeeper/operator/templates/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: {{ .Params.IMAGE_PULL_POLICY }}
-          image: "zookeeper:3.4.14"
+          image: "zookeeper:3.6.2"
           resources:
             requests:
               memory: {{ .Params.MEMORY }}

--- a/repository/zookeeper/operator/templates/validation.yaml
+++ b/repository/zookeeper/operator/templates/validation.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: {{ .Params.IMAGE_PULL_POLICY }}
-          image: "zookeeper:3.4.14"
+          image: "zookeeper:3.6.2"
           env:
             - name: CONN
               value: {{ if gt (int .Params.NODE_COUNT) 0 }} {{ .Name }}-zookeeper-0.{{ .Name }}-hs:{{ .Params.CLIENT_PORT }}{{- $root := . -}}{{ range $i, $v := untilStep 1 (int .Params.NODE_COUNT) 1 }},{{ $root.Name }}-zookeeper-{{ $v }}.{{ $root.Name }}-hs:{{ $root.Params.CLIENT_PORT }}{{ end }}{{ end }}

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/00-install.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/00-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk
 spec:
   operatorVersion:
-    name: zookeeper-3.4.14-0.3.1
+    name: zookeeper-3.6.2-0.3.3
     namespace: default
     kind: OperatorVersion
   name: "zk"

--- a/repository/zookeeper/tests/zookeeper-upgrade-test/01-resize.yaml
+++ b/repository/zookeeper/tests/zookeeper-upgrade-test/01-resize.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk
 spec:
   operatorVersion:
-    name: zookeeper-3.4.14-0.3.1
+    name: zookeeper-3.6.2-0.3.3
     namespace: default
     kind: OperatorVersion
   name: "zk"


### PR DESCRIPTION
- Add 4lw.commands.whitelist parameter to bootstrap.sh to allow health check
- Zookeeper image bump in validation.yaml and statefulset.yaml
- Documentation update
- Operator version update to 0.3.3
- Update test plan

Signed-off-by: Lionel Herbet <lionel.herbet@gmail.com>