### PR TITLE
fix: complete removal of `./templates` folder started in #311

### DIFF
--- a/kudo-test.yaml.tmpl
+++ b/kudo-test.yaml.tmpl
@@ -16,8 +16,6 @@ commands:
   - command: ./bin/kubectl-kudo install --skip-instance ./repository/redis/operator/
   - command: ./bin/kubectl-kudo install --skip-instance ./repository/spark/operator/
   - command: ./bin/kubectl-kudo install --skip-instance ./repository/zookeeper/operator/
-  - command: ./bin/kubectl-kudo install --skip-instance ./templates/akka/operator-shoppingcart/
-  - command: ./bin/kubectl-kudo install --skip-instance ./templates/akka/operator/
 testDirs:
 - ./repository/zookeeper/tests
 - ./repository/kafka/tests


### PR DESCRIPTION
This should fix failure of operator-test in kudobuilder/kudo repo (like observed in https://app.circleci.com/pipelines/github/kudobuilder/kudo/5631/workflows/28d9ebb7-bbc4-4218-a9fa-a4a52505a62e/jobs/17182)